### PR TITLE
Fix caching of Commodore results

### DIFF
--- a/src/commodore/index.spec.ts
+++ b/src/commodore/index.spec.ts
@@ -15,7 +15,6 @@ import { getGlobalConfig } from 'renovate/dist/config/global';
 
 import { getFixturePath, loadFixture } from '../test/util';
 import { defaultConfig, extractPackageFile } from './index';
-import { clearCache } from './inventory';
 
 const params1 = loadFixture('1/params.yml');
 const kube2 = loadFixture('2/kubernetes.yml');
@@ -55,11 +54,6 @@ async function setupGlobalRepo(fixtureId: string): Promise<string> {
 
 beforeAll(() => {
   return mkdir('/tmp/renovate', { recursive: true });
-});
-
-/* Clear commodore inventory components result cache before each test run */
-beforeEach(() => {
-  clearCache();
 });
 
 describe('src/commodore/index', () => {

--- a/src/commodore/inventory.ts
+++ b/src/commodore/inventory.ts
@@ -8,8 +8,8 @@ import type { CommodoreParameters, Facts } from './types';
 
 let versionCache: Map<string, CommodoreParameters> = new Map();
 
-function cacheKey(facts: Facts): string {
-  return `${facts.distribution}-${facts.cloud}-${facts.region}`;
+function cacheKey(prefix: string, facts: Facts): string {
+  return `${prefix}${facts.distribution}-${facts.cloud}-${facts.region}`;
 }
 
 export function clearCache(): void {
@@ -38,14 +38,14 @@ export async function renderInventory(
   extraValuesPath: string,
   facts: Facts
 ): Promise<CommodoreParameters> {
-  const ck: string = cacheKey(facts);
+  const ck: string = cacheKey(`${repoPath}-`, facts);
   let cachedVersions = versionCache.get(ck);
   if (cachedVersions !== undefined) {
     logger.info(`Reusing cached versions for ${ck}`);
     return cachedVersions;
   }
 
-  const factsPath: string = await writeFactsFile(ck, facts);
+  const factsPath: string = await writeFactsFile(cacheKey('', facts), facts);
 
   /* construct and execute Commodore command */
   var command = `commodore inventory components ${globalPath} ${repoPath} -ojson -f ${factsPath} -f ${extraValuesPath}`;

--- a/src/commodore/inventory.ts
+++ b/src/commodore/inventory.ts
@@ -12,10 +12,6 @@ function cacheKey(prefix: string, facts: Facts): string {
   return `${prefix}${facts.distribution}-${facts.cloud}-${facts.region}`;
 }
 
-export function clearCache(): void {
-  versionCache = new Map();
-}
-
 export async function writeFactsFile(
   cacheKey: string,
   facts: Facts


### PR DESCRIPTION
Previously commodore results for different tenant repos would use the same key in the commodore inventory cache.

This commit prefixes the cache key for the inventory with the path of the repo we're renovating to ensure that we don't share cache keys between different repos.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.

Contributors guide: ./CONTRIBUTING.md
-->

## Checklist

<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] PR contains a single logical change (to build a better changelog).
- [x] Update tests.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
