### PR TITLE
Expose Lieutenant token config only via environment variable

### DIFF
--- a/src/commodore/index.ts
+++ b/src/commodore/index.ts
@@ -127,21 +127,27 @@ export async function extractPackageFile(
     const globalRepo: RepoConfig = await cloneGlobalRepo(config);
 
     if (config.lieutenantURL && config.lieutenantURL != '') {
-      logger.info(`Querying Lieutenant at ${config.lieutenantURL}`);
-      try {
-        clusterInfo = await fetchClusterInfo(config, cluster.name);
-      } catch (error: any) {
-        if (error instanceof LieutenantError) {
-          const err = error as LieutenantError;
-          if (err.statusCode == 404) {
-            logger.debug(`Lieutenant query returned 404 for ${cluster.name}`);
+      if (config.lieutenantToken == '') {
+        logger.warn(
+          `Lieutenant token is empty. Renovate won't try to query the Lieutenant API at ${config.lieutenantURL}`
+        );
+      } else {
+        logger.info(`Querying Lieutenant at ${config.lieutenantURL}`);
+        try {
+          clusterInfo = await fetchClusterInfo(config, cluster.name);
+        } catch (error: any) {
+          if (error instanceof LieutenantError) {
+            const err = error as LieutenantError;
+            if (err.statusCode == 404) {
+              logger.debug(`Lieutenant query returned 404 for ${cluster.name}`);
+            } else {
+              logger.info(
+                `Error querying Lieutenant for ${cluster.name}: statusCode=${err.statusCode}, reason=${err.message}`
+              );
+            }
           } else {
-            logger.info(
-              `Error querying Lieutenant for ${cluster.name}: statusCode=${err.statusCode}, reason=${err.message}`
-            );
+            logger.error(`Unexpected error querying Lieutenant: ${error}`);
           }
-        } else {
-          logger.error(`Unexpected error querying Lieutenant: ${error}`);
         }
       }
     }

--- a/src/commodore/readme.md
+++ b/src/commodore/readme.md
@@ -32,10 +32,10 @@ The manager currently adds the following options to the standard renovate config
 - `lieutenantURL`: The URL of the Lieutenant API to query for cluster facts when renovating tenant repos.
   If this option is not set or the empty string, the manager will not try to query the Lieutenant API.
 
-- `lieutenantToken`: The API token for the configured Lieutenant API.
-  By default, the manager extracts the API token from environment variable `LIEUTENANT_API_TOKEN`.
-  If a different environment variable should be used, users can set this parameter to `process.env.<API_TOKEN_VAR>` in `config.js`, replacing `<API_TOKEN_VAR>` with the name of the environment variable to use.
-  We don't recommend configuring the Lieutenant token in plain text in `renovate.json`.
+- `lieutenantTokenEnvVar`: The environment variable from which the Lieutenant API token is read.
+  We suggest to configure a token for each required Lieutenant API as an environment variable in the Renovate runner execution environment.
+  With that setup, users can select the token to use by specifying the corresponding environment variable in `lieutenantTokenEnvVar`.
+  This option defaults to `LIEUTENANT_API_TOKEN`.
 
 ### Extra configuration file
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,7 @@
 import { existsSync, rmSync } from 'fs';
 import api from 'renovate/dist/manager/api.js';
 import { logger } from 'renovate/dist/logger';
+import type { AllConfig } from 'renovate/dist/config/types';
 
 import * as commodore from './commodore';
 import { globalRepos } from './commodore/util';
@@ -39,12 +40,37 @@ options.push({
   default: '',
 });
 options.push({
-  name: 'lieutenantToken',
-  description:
-    'Token for Lieutenant API. Used to fetch cluster facts when renovating tenant repos.',
+  name: 'lieutenantTokenEnvVar',
+  description: 'Environment variable to read the Lieutenant API token from.',
   type: 'string',
-  default: process.env.LIEUTENANT_API_TOKEN,
+  default: 'LIEUTENANT_API_TOKEN',
 });
+
+// Patch Renovate's `filterConfig` so we can implement the dynamic Env var
+// config for the Lieutenant token. We need the require() here so we can
+// overwrite the exported function.
+// Note: We don't patch `getRepositoryConfig`, but instead `filterConfig`
+// which is called by `getRepositoryConfig`. This is because the call site of
+// `getRepositoryConfig` doesn't use the exported function but rather calls
+// the original function in the same module directly, so patching the exported
+// `getRepositoryConfig` here has no effect.
+// @ts-ignore
+const renovate_config = require('renovate/dist/config');
+const origFilterConfig = renovate_config.filterConfig;
+function patchedFilterConfig(
+  inputConfig: AllConfig,
+  manager: string
+): AllConfig {
+  let cfg = origFilterConfig(inputConfig, manager);
+  if (cfg.lieutenantTokenEnvVar) {
+    const token = process.env[cfg.lieutenantTokenEnvVar];
+    if (token) {
+      cfg.lieutenantToken = token;
+    }
+  }
+  return cfg;
+}
+renovate_config.filterConfig = patchedFilterConfig;
 
 // Patch renovate finalizer, we need the require() here despite what the TS
 // hint indicates. However, seems that suggestions cannot be suppressed with


### PR DESCRIPTION
Instead of exposing a `lieutenantToken` config option which defaults to environment variable `LIEUTENANT_API_TOKEN`, we expose a config option which allows specifying the environment variable from which the token should be read.

With the previous approach, there was no way for users to securely specify different Lieutenant tokens for different repositories, except for providing the token in plain text in the repository's `renovate.json`.

With the new approach, users can provide all the required Lieutenant secrets as environment variables in the Renovate runner execution environment, and users can select an appropriate token for their configured Lieutenant instance.

Note: even though we don't expose the `lieutenantToken` option anymore, we internally still set the field on the config object, so the commodore manager implementation can still read the token from the provided config object.

To achieve this, we need to patch Renovate's `getRepositoryConfig` method. However, since that method is in the same module as it's defined, patching it directly doesn't inject our patch where we need it. Instead we patch `filterConfig` which is called by `getRepositoryConfig` to set `config.lieutenantToken` to the value of the environment variable specified with `config.lieutenanttokenEnvVar`, if that environment variable is set.

## Checklist

<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] PR contains a single logical change (to build a better changelog).
- [x] Update the documentation.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
