### PR TITLE
Recursively parse every object

### DIFF
--- a/src/commodore-docker/__fixtures__/4/params.yml
+++ b/src/commodore-docker/__fixtures__/4/params.yml
@@ -1,0 +1,25 @@
+parameters:
+  allover:
+    images:
+      steward:
+        image: docker.io/projectsyn/steward
+        tag: 'v0.6.0@sha256:36468cfc3cdd3877e80b08a68426530a1bcd5a17fe03bfc301e63027ded30272'
+        unrelated:
+          tag: 5
+      argocd:
+        registry:
+          acutally: 'something else'
+        image: quay.io/argoproj/argocd
+        tag: 'v2.0.4@sha256:976dfbfadb817ba59f4f641597a13df7b967cd5a1059c966fa843869c9463348'
+    helm_values:
+      image:
+        repository: quay.io/keycloak/keycloak
+        tag: '15.0.2'
+    other:
+      incomplete:
+        registry: quay.io
+      bar:
+        buzz:
+          registry: docker.io
+          repository: projectsyn/buzz
+          version: v0.6.0

--- a/src/commodore-docker/__fixtures__/5/params.yml
+++ b/src/commodore-docker/__fixtures__/5/params.yml
@@ -1,0 +1,19 @@
+parameters:
+  nested:
+    blub:
+      images:
+        steward:
+          image: docker.io/projectsyn/steward
+          tag: 'v0.6.0@sha256:36468cfc3cdd3877e80b08a68426530a1bcd5a17fe03bfc301e63027ded30272'
+          argocd:
+            image: quay.io/argoproj/argocd
+            tag: 'v2.0.4@sha256:976dfbfadb817ba59f4f641597a13df7b967cd5a1059c966fa843869c9463348'
+            keycloak:
+              repository: quay.io/keycloak/keycloak
+              tag: '15.0.2'
+              incomplete:
+                registry: quay.io
+                buzz:
+                  registry: docker.io
+                  repository: projectsyn/buzz
+                  version: v0.6.0

--- a/src/commodore-docker/__snapshots__/index.spec.ts.snap
+++ b/src/commodore-docker/__snapshots__/index.spec.ts.snap
@@ -81,3 +81,85 @@ Array [
   },
 ]
 `;
+
+exports[`manager/commodore/index extractPackageFile() returns images that are deeply nested in each other 1`] = `
+Array [
+  Object {
+    "autoReplaceStringTemplate": "{{newValue}}{{#if newDigest}}@{{newDigest}}{{/if}}",
+    "currentDigest": "sha256:36468cfc3cdd3877e80b08a68426530a1bcd5a17fe03bfc301e63027ded30272",
+    "currentValue": "v0.6.0",
+    "datasource": "docker",
+    "depName": "docker.io/projectsyn/steward",
+    "replaceString": "v0.6.0@sha256:36468cfc3cdd3877e80b08a68426530a1bcd5a17fe03bfc301e63027ded30272",
+    "versioning": "docker",
+  },
+  Object {
+    "autoReplaceStringTemplate": "{{newValue}}{{#if newDigest}}@{{newDigest}}{{/if}}",
+    "currentDigest": "sha256:976dfbfadb817ba59f4f641597a13df7b967cd5a1059c966fa843869c9463348",
+    "currentValue": "v2.0.4",
+    "datasource": "docker",
+    "depName": "quay.io/argoproj/argocd",
+    "replaceString": "v2.0.4@sha256:976dfbfadb817ba59f4f641597a13df7b967cd5a1059c966fa843869c9463348",
+    "versioning": "docker",
+  },
+  Object {
+    "autoReplaceStringTemplate": "{{newValue}}{{#if newDigest}}@{{newDigest}}{{/if}}",
+    "currentDigest": undefined,
+    "currentValue": "15.0.2",
+    "datasource": "docker",
+    "depName": "quay.io/keycloak/keycloak",
+    "replaceString": "15.0.2",
+    "versioning": "docker",
+  },
+  Object {
+    "autoReplaceStringTemplate": "{{newValue}}{{#if newDigest}}@{{newDigest}}{{/if}}",
+    "currentDigest": undefined,
+    "currentValue": "v0.6.0",
+    "datasource": "docker",
+    "depName": "docker.io/projectsyn/buzz",
+    "replaceString": "v0.6.0",
+    "versioning": "docker",
+  },
+]
+`;
+
+exports[`manager/commodore/index extractPackageFile() returns images that are not declared in parameters.<component>.images 1`] = `
+Array [
+  Object {
+    "autoReplaceStringTemplate": "{{newValue}}{{#if newDigest}}@{{newDigest}}{{/if}}",
+    "currentDigest": "sha256:36468cfc3cdd3877e80b08a68426530a1bcd5a17fe03bfc301e63027ded30272",
+    "currentValue": "v0.6.0",
+    "datasource": "docker",
+    "depName": "docker.io/projectsyn/steward",
+    "replaceString": "v0.6.0@sha256:36468cfc3cdd3877e80b08a68426530a1bcd5a17fe03bfc301e63027ded30272",
+    "versioning": "docker",
+  },
+  Object {
+    "autoReplaceStringTemplate": "{{newValue}}{{#if newDigest}}@{{newDigest}}{{/if}}",
+    "currentDigest": "sha256:976dfbfadb817ba59f4f641597a13df7b967cd5a1059c966fa843869c9463348",
+    "currentValue": "v2.0.4",
+    "datasource": "docker",
+    "depName": "quay.io/argoproj/argocd",
+    "replaceString": "v2.0.4@sha256:976dfbfadb817ba59f4f641597a13df7b967cd5a1059c966fa843869c9463348",
+    "versioning": "docker",
+  },
+  Object {
+    "autoReplaceStringTemplate": "{{newValue}}{{#if newDigest}}@{{newDigest}}{{/if}}",
+    "currentDigest": undefined,
+    "currentValue": "15.0.2",
+    "datasource": "docker",
+    "depName": "quay.io/keycloak/keycloak",
+    "replaceString": "15.0.2",
+    "versioning": "docker",
+  },
+  Object {
+    "autoReplaceStringTemplate": "{{newValue}}{{#if newDigest}}@{{newDigest}}{{/if}}",
+    "currentDigest": undefined,
+    "currentValue": "v0.6.0",
+    "datasource": "docker",
+    "depName": "docker.io/projectsyn/buzz",
+    "replaceString": "v0.6.0",
+    "versioning": "docker",
+  },
+]
+`;

--- a/src/commodore-docker/index.spec.ts
+++ b/src/commodore-docker/index.spec.ts
@@ -5,6 +5,8 @@ import { expect, describe, it } from '@jest/globals';
 const params1 = loadFixture('1/params.yml');
 const params2 = loadFixture('2/params.yml');
 const params3 = loadFixture('3/params.yml');
+const params4 = loadFixture('4/params.yml');
+const params5 = loadFixture('5/params.yml');
 
 describe('manager/commodore/index', () => {
   describe('extractPackageFile()', () => {
@@ -25,6 +27,24 @@ describe('manager/commodore/index', () => {
     });
     it('returns images for non standard but common formats', () => {
       const res = extractPackageFile(params3, '3/params.yml');
+      expect(res).not.toBeNull();
+      if (res) {
+        const deps = res.deps;
+        expect(deps).toMatchSnapshot();
+        expect(deps).toHaveLength(4);
+      }
+    });
+    it('returns images that are not declared in parameters.<component>.images', () => {
+      const res = extractPackageFile(params4, '4/params.yml');
+      expect(res).not.toBeNull();
+      if (res) {
+        const deps = res.deps;
+        expect(deps).toMatchSnapshot();
+        expect(deps).toHaveLength(4);
+      }
+    });
+    it('returns images that are deeply nested in each other', () => {
+      const res = extractPackageFile(params5, '5/params.yml');
       expect(res).not.toBeNull();
       if (res) {
         const deps = res.deps;

--- a/src/commodore-docker/index.ts
+++ b/src/commodore-docker/index.ts
@@ -27,11 +27,7 @@ export function extractPackageFile(
     return null;
   }
 
-  const deps = Object.values(doc.parameters).flatMap((component: any) =>
-    component.images !== undefined
-      ? extractImageDependencies(component.images)
-      : []
-  );
+  const deps = extractImageDependencies(doc.parameters);
 
   if (deps.length == 0) {
     return null;
@@ -41,11 +37,15 @@ export function extractPackageFile(
 }
 
 function extractImageDependencies(
-  images: Record<string, any>
+  obj: Record<string, any>
 ): PackageDependency[] {
-  return Object.values(images)
+  if (obj === undefined || obj === null || typeof obj !== 'object') {
+    return [];
+  }
+  return Object.values(obj)
     .map(parseImageDependency)
-    .filter((dep): dep is PackageDependency => dep !== null);
+    .filter((dep): dep is PackageDependency => dep !== null)
+    .concat(Object.values(obj).flatMap(extractImageDependencies));
 }
 
 export function parseImageDependency(image: any): PackageDependency | null {

--- a/src/commodore-docker/readme.md
+++ b/src/commodore-docker/readme.md
@@ -2,7 +2,7 @@
 
 Extracts all container image dependencies of a Commodore component.
 
-By default, the manager only searches in `class/defaults.yml` for entries in `parameters.components.*.images`.
+By default, the manager only searches in `class/defaults.yml`.
 The manager is guaranteed to find image dependencies that adhere to the [best practices for container image dependencies](https://syn.tools/syn/explanations/commodore-components/container-images.html).
 It will attempt to parse other common dependency structures, but might not be able to parse them correctly.
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.

Contributors guide: ./CONTRIBUTING.md
-->

This switches to trying to parse any object as a image dependency. That way we can find dependencies such as: https://github.com/projectsyn/component-keycloak/blob/e62be9031c9d4a2fe42d473429da1cef335169c2/class/defaults.yml#L156.

However this could very well lead to false positives. I'm unsure if we should implement this or not. 

## Checklist

<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] PR contains a single logical change (to build a better changelog).
- [x] Update the documentation.
- [x] Update tests.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
