### PR TITLE
Add support for renovating Helm chart versions in component defaults

### DIFF
--- a/src/commodore-helm/__fixtures__/1/class/component-name.yml
+++ b/src/commodore-helm/__fixtures__/1/class/component-name.yml
@@ -1,0 +1,22 @@
+parameters:
+  kapitan:
+    dependencies:
+      - type: https
+        source: https://example.com/test.yaml
+        output_path: test.yaml
+      - type: helm
+        source: https://charts.example.com/
+        chart_name: chart-1
+        version: ${component_name:charts:chart-1}
+        output_path: charts/chart-1
+      - type: helm
+        source: https://charts2.example.com/
+        chart_name: chart-2
+        version: ${component_name:charts:chart-2}
+        output_path: charts/chart-2
+      # This entry should be ignored
+      - type: helm
+        source: https://charts3.example.com/
+        chart_name: chart-3
+        version: v0.0.1
+        output_path: charts/chart-3

--- a/src/commodore-helm/__fixtures__/1/class/defaults.yml
+++ b/src/commodore-helm/__fixtures__/1/class/defaults.yml
@@ -1,0 +1,10 @@
+parameters:
+  component_name:
+    charts:
+      chart-1: 1.2.3
+      chart-2: 4.5.6
+    other_parameter: test
+  other_key:
+    testing: true
+    charts:
+      chart-3: 7.8.9

--- a/src/commodore-helm/__fixtures__/2/class/defaults.yml
+++ b/src/commodore-helm/__fixtures__/2/class/defaults.yml
@@ -1,0 +1,10 @@
+parameters:
+  long_component_name:
+    charts:
+      chart-1: 1.2.3
+      chart-2: 4.5.6
+    other_parameter: test
+  other_key:
+    testing: true
+    charts:
+      chart-3: 7.8.9

--- a/src/commodore-helm/__fixtures__/2/class/long-component-name.yml
+++ b/src/commodore-helm/__fixtures__/2/class/long-component-name.yml
@@ -1,0 +1,16 @@
+parameters:
+  kapitan:
+    dependencies:
+      - type: https
+        source: https://example.com/test.yaml
+        output_path: test.yaml
+      - type: helm
+        source: https://charts.example.com/
+        chart_name: chart-1
+        version: ${long_component_name:charts:chart-1}
+        output_path: charts/chart-1
+      - type: helm
+        source: https://charts2.example.com/
+        chart_name: chart-2
+        version: ${long_component_name:charts:chart-2}
+        output_path: charts/chart-2

--- a/src/commodore-helm/__fixtures__/3/class/component-name.yml
+++ b/src/commodore-helm/__fixtures__/3/class/component-name.yml
@@ -1,0 +1,16 @@
+parameters:
+  kapitan:
+    dependencies:
+      - type: https
+        source: https://example.com/test.yaml
+        output_path: test.yaml
+      - type: helm
+        source: https://charts.example.com/
+        chart_name: chart-1
+        version: ${component_name:charts:chart_1}
+        output_path: charts/chart-1
+      - type: helm
+        source: https://charts2.example.com/
+        chart_name: chart-2
+        version: ${component_name:charts:chart2}
+        output_path: charts/chart-2

--- a/src/commodore-helm/__fixtures__/3/class/defaults.yml
+++ b/src/commodore-helm/__fixtures__/3/class/defaults.yml
@@ -1,0 +1,10 @@
+parameters:
+  component_name:
+    charts:
+      chart_1: 1.2.3
+      chart2: 4.5.6
+    other_parameter: test
+  other_key:
+    testing: true
+    charts:
+      chart-3: 7.8.9

--- a/src/commodore-helm/__fixtures__/4/class/component-name.yml
+++ b/src/commodore-helm/__fixtures__/4/class/component-name.yml
@@ -1,0 +1,1 @@
+parameters: {}

--- a/src/commodore-helm/__fixtures__/4/class/defaults.yml
+++ b/src/commodore-helm/__fixtures__/4/class/defaults.yml
@@ -1,0 +1,4 @@
+parameters:
+  component_name:
+    test: testing
+    namespace: syn-ns

--- a/src/commodore-helm/__fixtures__/5/class/component-name-2.yml
+++ b/src/commodore-helm/__fixtures__/5/class/component-name-2.yml
@@ -1,0 +1,2 @@
+parameters:
+  kapitan: {}

--- a/src/commodore-helm/__fixtures__/5/class/component-name.yml
+++ b/src/commodore-helm/__fixtures__/5/class/component-name.yml
@@ -1,0 +1,1 @@
+parameters: {}

--- a/src/commodore-helm/__fixtures__/5/class/defaults.yml
+++ b/src/commodore-helm/__fixtures__/5/class/defaults.yml
@@ -1,0 +1,8 @@
+parameters:
+  component_name:
+    charts:
+      chart-1: '1.2.3'
+
+  component_name_2:
+    charts:
+      chart-1: '4.5.6'

--- a/src/commodore-helm/__fixtures__/6/class/component-name.yml
+++ b/src/commodore-helm/__fixtures__/6/class/component-name.yml
@@ -1,0 +1,19 @@
+parameters:
+  kapitan:
+    dependencies:
+      - type: https
+        source: https://example.com/test.yaml
+        output_path: test.yaml
+      - type: helm
+        source: https://charts.example.com/
+        chart_name: chart-1
+        version: ${component_name:charts:chart-1}
+        output_path: charts/chart-1
+      - type: helm
+        source: https://charts2.example.com/
+        chart_name: chart-2
+        version: ${component_name:charts:chart-2}
+        output_path: charts/chart-2
+      # This entry is invalid
+      - type: helm
+        output_path: charts/chart-3

--- a/src/commodore-helm/__fixtures__/6/class/defaults.yml
+++ b/src/commodore-helm/__fixtures__/6/class/defaults.yml
@@ -1,0 +1,10 @@
+parameters:
+  component_name:
+    charts:
+      chart-1: 1.2.3
+      chart-2: 4.5.6
+    other_parameter: test
+  other_key:
+    testing: true
+    charts:
+      chart-3: 7.8.9

--- a/src/commodore-helm/__snapshots__/index.spec.ts.snap
+++ b/src/commodore-helm/__snapshots__/index.spec.ts.snap
@@ -1,0 +1,70 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`manager/commodore-helm/index extractAllPackageFiles() extracts Helm dependencies with mismatched names 1`] = `
+Array [
+  Object {
+    "currentValue": "1.2.3",
+    "depName": "chart-1",
+    "groupName": "component-name",
+    "propSource": "chart_1",
+    "registryUrls": Array [
+      "https://charts.example.com/",
+    ],
+  },
+  Object {
+    "currentValue": "4.5.6",
+    "depName": "chart-2",
+    "groupName": "component-name",
+    "propSource": "chart2",
+    "registryUrls": Array [
+      "https://charts2.example.com/",
+    ],
+  },
+]
+`;
+
+exports[`manager/commodore-helm/index extractAllPackageFiles() extracts standard Helm dependencies 1`] = `
+Array [
+  Object {
+    "currentValue": "1.2.3",
+    "depName": "chart-1",
+    "groupName": "component-name",
+    "propSource": "chart-1",
+    "registryUrls": Array [
+      "https://charts.example.com/",
+    ],
+  },
+  Object {
+    "currentValue": "4.5.6",
+    "depName": "chart-2",
+    "groupName": "component-name",
+    "propSource": "chart-2",
+    "registryUrls": Array [
+      "https://charts2.example.com/",
+    ],
+  },
+]
+`;
+
+exports[`manager/commodore-helm/index extractAllPackageFiles() extracts standard Helm dependencies for components with long names 1`] = `
+Array [
+  Object {
+    "currentValue": "1.2.3",
+    "depName": "chart-1",
+    "groupName": "long-component-name",
+    "propSource": "chart-1",
+    "registryUrls": Array [
+      "https://charts.example.com/",
+    ],
+  },
+  Object {
+    "currentValue": "4.5.6",
+    "depName": "chart-2",
+    "groupName": "long-component-name",
+    "propSource": "chart-2",
+    "registryUrls": Array [
+      "https://charts2.example.com/",
+    ],
+  },
+]
+`;

--- a/src/commodore-helm/__snapshots__/index.spec.ts.snap
+++ b/src/commodore-helm/__snapshots__/index.spec.ts.snap
@@ -68,3 +68,16 @@ Array [
   },
 ]
 `;
+
+exports[`manager/commodore-helm/index extractPackageFile() extracts Helm chart versions when called with sufficient config 1`] = `
+Array [
+  Object {
+    "currentValue": "1.2.3",
+    "depName": "chart-1",
+  },
+  Object {
+    "currentValue": "4.5.6",
+    "depName": "chart-2",
+  },
+]
+`;

--- a/src/commodore-helm/__snapshots__/index.spec.ts.snap
+++ b/src/commodore-helm/__snapshots__/index.spec.ts.snap
@@ -69,6 +69,19 @@ Array [
 ]
 `;
 
+exports[`manager/commodore-helm/index extractPackageFile() extracts Helm chart versions for mismatched keys when called with sufficient config 1`] = `
+Array [
+  Object {
+    "currentValue": "1.2.3",
+    "depName": "chart-1",
+  },
+  Object {
+    "currentValue": "4.5.6",
+    "depName": "chart-2",
+  },
+]
+`;
+
 exports[`manager/commodore-helm/index extractPackageFile() extracts Helm chart versions when called with sufficient config 1`] = `
 Array [
   Object {
@@ -78,6 +91,19 @@ Array [
   Object {
     "currentValue": "4.5.6",
     "depName": "chart-2",
+  },
+]
+`;
+
+exports[`manager/commodore-helm/index extractPackageFile() handles wrong dependency info gracefully 1`] = `
+Array [
+  Object {
+    "currentValue": "1.2.3",
+    "skipReason": "invalid-dependency-specification",
+  },
+  Object {
+    "currentValue": "4.5.6",
+    "skipReason": "invalid-dependency-specification",
   },
 ]
 `;

--- a/src/commodore-helm/index.spec.ts
+++ b/src/commodore-helm/index.spec.ts
@@ -1,4 +1,4 @@
-import { loadFixture, getFixturePath } from '../test/util';
+import { loadFixture, getFixturePath, getLoggerErrors } from '../test/util';
 import {
   extractPackageFile,
   extractAllPackageFiles,
@@ -8,10 +8,7 @@ import { beforeEach, expect, describe, it } from '@jest/globals';
 
 import { getGlobalConfig } from 'renovate/dist/config/global';
 
-import type { BunyanRecord } from 'renovate/dist/logger/types';
-import { ERROR } from 'bunyan';
-
-import { clearProblems, getProblems } from 'renovate/dist/logger';
+import { clearProblems } from 'renovate/dist/logger';
 
 jest.mock('renovate/dist/config/global');
 function mockGetGlobalConfig(fixtureId: string): void {
@@ -24,11 +21,6 @@ function mockGetGlobalConfig(fixtureId: string): void {
       cacheDir: '/tmp/renovate',
     };
   });
-}
-
-function getLoggerErrors(): BunyanRecord[] {
-  const loggerErrors = getProblems().filter((p) => p.level >= ERROR);
-  return loggerErrors;
 }
 
 beforeEach(() => {

--- a/src/commodore-helm/index.spec.ts
+++ b/src/commodore-helm/index.spec.ts
@@ -1,5 +1,9 @@
 import { loadFixture, getFixturePath } from '../test/util';
-import { extractPackageFile, extractAllPackageFiles, extractHelmChartDependencies } from './index';
+import {
+  extractPackageFile,
+  extractAllPackageFiles,
+  extractHelmChartDependencies,
+} from './index';
 import { beforeEach, expect, describe, it } from '@jest/globals';
 
 import { getGlobalConfig } from 'renovate/dist/config/global';
@@ -10,9 +14,7 @@ import { ERROR } from 'bunyan';
 import { clearProblems, getProblems } from 'renovate/dist/logger';
 
 jest.mock('renovate/dist/config/global');
-function mockGetGlobalConfig(
-  fixtureId: string,
-): void {
+function mockGetGlobalConfig(fixtureId: string): void {
   const mockGetGlobalConfigFn = getGlobalConfig as jest.MockedFunction<
     typeof getGlobalConfig
   >;
@@ -47,23 +49,26 @@ const config1 = {
       depName: 'chart-2',
       propSource: 'chart-2',
       groupName: 'component-name',
-    }
-  ]
+    },
+  ],
 };
-
 
 describe('manager/commodore-helm/index', () => {
   describe('extractPackageFile()', () => {
     it('returns null when called to discover dependencies', () => {
-      const res = extractPackageFile(defaults1, 'class/defaults.yml', {})
+      const res = extractPackageFile(defaults1, 'class/defaults.yml', {});
       expect(res).toBeNull();
     });
     it('returns null when called on a file other than `class/defaults.ya?ml`', () => {
-      const res = extractPackageFile(defaults1, 'class/component-name.yml', config1)
+      const res = extractPackageFile(
+        defaults1,
+        'class/component-name.yml',
+        config1
+      );
       expect(res).toBeNull();
     });
     it('extracts Helm chart versions when called with sufficient config', () => {
-      const res = extractPackageFile(defaults1, 'class/defaults.yml', config1)
+      const res = extractPackageFile(defaults1, 'class/defaults.yml', config1);
       expect(res).not.toBeNull();
       if (res) {
         expect(res.deps).toMatchSnapshot();
@@ -76,7 +81,10 @@ describe('manager/commodore-helm/index', () => {
   describe('extractAllPackageFiles()', () => {
     it('extracts standard Helm dependencies', async () => {
       mockGetGlobalConfig('1');
-      const res = await extractAllPackageFiles({}, ['class/defaults.yml', 'class/component-name.yml']);
+      const res = await extractAllPackageFiles({}, [
+        'class/defaults.yml',
+        'class/component-name.yml',
+      ]);
       const errors = getLoggerErrors();
       if (errors.length > 0) {
         console.log(errors);
@@ -96,7 +104,10 @@ describe('manager/commodore-helm/index', () => {
     });
     it('extracts standard Helm dependencies for components with long names', async () => {
       mockGetGlobalConfig('2');
-      const res = await extractAllPackageFiles({}, ['class/defaults.yml', 'class/long-component-name.yml']);
+      const res = await extractAllPackageFiles({}, [
+        'class/defaults.yml',
+        'class/long-component-name.yml',
+      ]);
       const errors = getLoggerErrors();
       if (errors.length > 0) {
         console.log(errors);
@@ -116,7 +127,10 @@ describe('manager/commodore-helm/index', () => {
     });
     it('extracts Helm dependencies with mismatched names', async () => {
       mockGetGlobalConfig('3');
-      const res = await extractAllPackageFiles({}, ['class/defaults.yml', 'class/component-name.yml']);
+      const res = await extractAllPackageFiles({}, [
+        'class/defaults.yml',
+        'class/component-name.yml',
+      ]);
       const errors = getLoggerErrors();
       if (errors.length > 0) {
         console.log(errors);

--- a/src/commodore-helm/index.spec.ts
+++ b/src/commodore-helm/index.spec.ts
@@ -149,26 +149,25 @@ describe('manager/commodore-helm/index', () => {
       expect(errors.length).toBe(0);
       expect(res).toBeNull();
     });
-    it('records an error for non-component repositories', async () => {
-      mockGetGlobalConfig('5');
-      const res = await extractAllPackageFiles({}, ['class/yuhu.yml']);
+    it("records an error for repositories which don't have exactly 2 package files", async () => {
+      const res = await extractAllPackageFiles({}, ['class/defaults.yml']);
+      expect(res).toBeNull();
+      const errors = getLoggerErrors();
+      expect(errors.length).toBe(1);
+      const err0 = errors[0];
+      expect(err0.msg).toBe('Expected exactly two package files, aborting.');
+    });
+    it('records an error for non-component repositories which have two package files', async () => {
+      const res = await extractAllPackageFiles({}, [
+        'class/test1.yml',
+        'class/test2.yml',
+      ]);
       expect(res).toBeNull();
       const errors = getLoggerErrors();
       expect(errors.length).toBe(1);
       const err0 = errors[0];
       expect(err0.msg).toBe(
         'Component repository has no `class/defaults.ya?ml`'
-      );
-    });
-    it('records an error for non-component repositories which have `class/defaults.yml`', async () => {
-      mockGetGlobalConfig('5');
-      const res = await extractAllPackageFiles({}, ['class/defaults.yml']);
-      expect(res).toBeNull();
-      const errors = getLoggerErrors();
-      expect(errors.length).toBe(1);
-      const err0 = errors[0];
-      expect(err0.msg).toBe(
-        'Unable to identify component name from package files'
       );
     });
   });

--- a/src/commodore-helm/index.spec.ts
+++ b/src/commodore-helm/index.spec.ts
@@ -149,5 +149,27 @@ describe('manager/commodore-helm/index', () => {
       expect(errors.length).toBe(0);
       expect(res).toBeNull();
     });
+    it('records an error for non-component repositories', async () => {
+      mockGetGlobalConfig('5');
+      const res = await extractAllPackageFiles({}, ['class/yuhu.yml']);
+      expect(res).toBeNull();
+      const errors = getLoggerErrors();
+      expect(errors.length).toBe(1);
+      const err0 = errors[0];
+      expect(err0.msg).toBe(
+        'Component repository has no `class/defaults.ya?ml`'
+      );
+    });
+    it('records an error for non-component repositories which have `class/defaults.yml`', async () => {
+      mockGetGlobalConfig('5');
+      const res = await extractAllPackageFiles({}, ['class/defaults.yml']);
+      expect(res).toBeNull();
+      const errors = getLoggerErrors();
+      expect(errors.length).toBe(1);
+      const err0 = errors[0];
+      expect(err0.msg).toBe(
+        'Unable to identify component name from package files'
+      );
+    });
   });
 });

--- a/src/commodore-helm/index.spec.ts
+++ b/src/commodore-helm/index.spec.ts
@@ -25,6 +25,8 @@ beforeEach(() => {
 });
 
 const defaults1 = loadFixture('1/class/defaults.yml');
+const defaults3 = loadFixture('3/class/defaults.yml');
+const defaults4 = loadFixture('4/class/defaults.yml');
 const config1 = {
   depName: 'chart-1',
   baseDeps: [
@@ -36,6 +38,52 @@ const config1 = {
     {
       depName: 'chart-2',
       propSource: 'chart-2',
+      groupName: 'component-name',
+    },
+  ],
+};
+const config1partial1 = {
+  depName: 'chart-1',
+  baseDeps: [],
+};
+const config1partial2 = {
+  depName: 'chart-1',
+  baseDeps: [
+    {
+      depName: 'chart-1',
+      propSource: 'chart-1',
+    },
+    {
+      depName: 'chart-2',
+      propSource: 'chart-2',
+    },
+  ],
+};
+const config1wrong1 = {
+  depName: 'chart-1',
+  baseDeps: [
+    {
+      depName: 'chart-1',
+      groupName: 'component-name',
+    },
+    {
+      depName: 'chart-2',
+      groupName: 'component-name',
+      propSource: 'chart-5',
+    },
+  ],
+};
+const config3 = {
+  depName: 'chart-1',
+  baseDeps: [
+    {
+      depName: 'chart-1',
+      propSource: 'chart_1',
+      groupName: 'component-name',
+    },
+    {
+      depName: 'chart-2',
+      propSource: 'chart2',
       groupName: 'component-name',
     },
   ],
@@ -55,6 +103,34 @@ describe('manager/commodore-helm/index', () => {
       );
       expect(res).toBeNull();
     });
+    it('returns null when provided empty dependency info', () => {
+      const res = extractPackageFile(
+        defaults1,
+        'class/defaults.yml',
+        config1partial1
+      );
+      expect(res).toBeNull();
+    });
+    it('returns null when provided incomplete dependency info', () => {
+      const res = extractPackageFile(
+        defaults1,
+        'class/defaults.yml',
+        config1partial2
+      );
+      expect(res).toBeNull();
+    });
+    it('handles wrong dependency info gracefully', () => {
+      const res = extractPackageFile(
+        defaults1,
+        'class/defaults.yml',
+        config1wrong1
+      );
+      expect(res).not.toBeNull();
+      if (res) {
+        expect(res.deps).toMatchSnapshot();
+        expect(res.deps.length).toBe(2);
+      }
+    });
     it('extracts Helm chart versions when called with sufficient config', () => {
       const res = extractPackageFile(defaults1, 'class/defaults.yml', config1);
       expect(res).not.toBeNull();
@@ -62,6 +138,18 @@ describe('manager/commodore-helm/index', () => {
         expect(res.deps).toMatchSnapshot();
         expect(res.deps.length).toBe(2);
       }
+    });
+    it('extracts Helm chart versions for mismatched keys when called with sufficient config', () => {
+      const res = extractPackageFile(defaults3, 'class/defaults.yml', config3);
+      expect(res).not.toBeNull();
+      if (res) {
+        expect(res.deps).toMatchSnapshot();
+        expect(res.deps.length).toBe(2);
+      }
+    });
+    it('gracefully ignores components without `charts` field', () => {
+      const res = extractPackageFile(defaults4, 'class/defaults.yml', config1);
+      expect(res).toBeNull();
     });
   });
   // This test also covers `extractHelmChartDependencies()`, since that's the

--- a/src/commodore-helm/index.spec.ts
+++ b/src/commodore-helm/index.spec.ts
@@ -1,9 +1,5 @@
 import { loadFixture, getFixturePath, getLoggerErrors } from '../test/util';
-import {
-  extractPackageFile,
-  extractAllPackageFiles,
-  extractHelmChartDependencies,
-} from './index';
+import { extractPackageFile, extractAllPackageFiles } from './index';
 import { beforeEach, expect, describe, it } from '@jest/globals';
 
 import { getGlobalConfig } from 'renovate/dist/config/global';

--- a/src/commodore-helm/index.spec.ts
+++ b/src/commodore-helm/index.spec.ts
@@ -1,0 +1,105 @@
+import { getFixturePath } from '../test/util';
+import { extractPackageFile, extractAllPackageFiles, extractHelmChartDependencies } from './index';
+import { beforeEach, expect, describe, it } from '@jest/globals';
+
+import { getGlobalConfig } from 'renovate/dist/config/global';
+
+import type { BunyanRecord } from 'renovate/dist/logger/types';
+import { ERROR } from 'bunyan';
+
+import { clearProblems, getProblems } from 'renovate/dist/logger';
+
+jest.mock('renovate/dist/config/global');
+function mockGetGlobalConfig(
+  fixtureId: string,
+): void {
+  const mockGetGlobalConfigFn = getGlobalConfig as jest.MockedFunction<
+    typeof getGlobalConfig
+  >;
+  mockGetGlobalConfigFn.mockImplementation(() => {
+    return {
+      localDir: getFixturePath(fixtureId),
+      cacheDir: '/tmp/renovate',
+    };
+  });
+}
+
+function getLoggerErrors(): BunyanRecord[] {
+  const loggerErrors = getProblems().filter((p) => p.level >= ERROR);
+  return loggerErrors;
+}
+
+beforeEach(() => {
+  // clear logger
+  clearProblems();
+});
+
+
+describe('manager/commodore-helm/index', () => {
+  describe('extractPackageFile()', () => {
+  });
+  describe('extractAllPackageFiles()', () => {
+    it('extracts standard Helm dependencies', async () => {
+      mockGetGlobalConfig('1');
+      const res = await extractAllPackageFiles({}, ['class/defaults.yml', 'class/component-name.yml']);
+      const errors = getLoggerErrors();
+      if (errors.length > 0) {
+        console.log(errors);
+      }
+      expect(errors.length).toBe(0);
+      expect(res).not.toBeNull();
+      if (res) {
+        expect(res.length).toBe(1);
+        if (res.length == 1) {
+          const res0 = res[0];
+          expect(res0.packageFile).toBe('class/defaults.yml');
+          const deps = res0.deps;
+          expect(deps).toMatchSnapshot();
+          expect(deps.length).toBe(2);
+        }
+      }
+    });
+    it('extracts standard Helm dependencies for components with long names', async () => {
+      mockGetGlobalConfig('2');
+      const res = await extractAllPackageFiles({}, ['class/defaults.yml', 'class/long-component-name.yml']);
+      const errors = getLoggerErrors();
+      if (errors.length > 0) {
+        console.log(errors);
+      }
+      expect(errors.length).toBe(0);
+      expect(res).not.toBeNull();
+      if (res) {
+        expect(res.length).toBe(1);
+        if (res.length == 1) {
+          const res0 = res[0];
+          expect(res0.packageFile).toBe('class/defaults.yml');
+          const deps = res0.deps;
+          expect(deps).toMatchSnapshot();
+          expect(deps.length).toBe(2);
+        }
+      }
+    });
+    it('extracts Helm dependencies with mismatched names', async () => {
+      mockGetGlobalConfig('3');
+      const res = await extractAllPackageFiles({}, ['class/defaults.yml', 'class/component-name.yml']);
+      const errors = getLoggerErrors();
+      if (errors.length > 0) {
+        console.log(errors);
+      }
+      expect(errors.length).toBe(0);
+      expect(res).not.toBeNull();
+      if (res) {
+        expect(res.length).toBe(1);
+        if (res.length == 1) {
+          const res0 = res[0];
+          expect(res0.packageFile).toBe('class/defaults.yml');
+          const deps = res0.deps;
+          expect(deps).toMatchSnapshot();
+          expect(deps.length).toBe(2);
+        }
+      }
+    });
+  });
+  describe('extractHelmChartDependencies()', () => {
+  });
+});

--- a/src/commodore-helm/index.spec.ts
+++ b/src/commodore-helm/index.spec.ts
@@ -149,6 +149,32 @@ describe('manager/commodore-helm/index', () => {
       expect(errors.length).toBe(0);
       expect(res).toBeNull();
     });
+    it('gracefully ignores components with `charts` parameter but no Kapitan config', async () => {
+      mockGetGlobalConfig('5');
+      const res = await extractAllPackageFiles({}, [
+        'class/defaults.yml',
+        'class/component-name.yml',
+      ]);
+      const errors = getLoggerErrors();
+      if (errors.length > 0) {
+        console.log(errors);
+      }
+      expect(errors.length).toBe(0);
+      expect(res).toBeNull();
+    });
+    it('gracefully ignores components with `charts` parameter but no Kapitan helm dependencies', async () => {
+      mockGetGlobalConfig('5');
+      const res = await extractAllPackageFiles({}, [
+        'class/defaults.yml',
+        'class/component-name-2.yml',
+      ]);
+      const errors = getLoggerErrors();
+      if (errors.length > 0) {
+        console.log(errors);
+      }
+      expect(errors.length).toBe(0);
+      expect(res).toBeNull();
+    });
     it("records an error for repositories which don't have exactly 2 package files", async () => {
       const res = await extractAllPackageFiles({}, ['class/defaults.yml']);
       expect(res).toBeNull();

--- a/src/commodore-helm/index.spec.ts
+++ b/src/commodore-helm/index.spec.ts
@@ -136,5 +136,18 @@ describe('manager/commodore-helm/index', () => {
         }
       }
     });
+    it('gracefully ignores components without Helm chart dependencies', async () => {
+      mockGetGlobalConfig('4');
+      const res = await extractAllPackageFiles({}, [
+        'class/defaults.yml',
+        'class/component-name.yml',
+      ]);
+      const errors = getLoggerErrors();
+      if (errors.length > 0) {
+        console.log(errors);
+      }
+      expect(errors.length).toBe(0);
+      expect(res).toBeNull();
+    });
   });
 });

--- a/src/commodore-helm/index.ts
+++ b/src/commodore-helm/index.ts
@@ -19,6 +19,10 @@ export const defaultConfig = {
   fileMatch: ['class/[^.]+.ya?ml$'],
 };
 
+function componentKeyFromName(componentName: string): string {
+  return componentName.replace(/-/g, '_');
+}
+
 // We need `extractPackageFile` since it gets called by `confirmIfDepUpdated`
 // via `doAutoReplace` because we don't provide a custom `updateDependency`
 // function ourselves.
@@ -43,7 +47,7 @@ export function extractPackageFile(
   const dep = config.baseDeps.find((d: PackageDependency) => {
     return d.depName === config.depName;
   });
-  const componentKey: string = dep.groupName.replace('-', '_');
+  const componentKey: string = componentKeyFromName(dep.groupName);
   const charts: Map<string, string> = defaults.parameters[componentKey].charts;
   if (!charts) {
     return null;
@@ -158,7 +162,7 @@ function extractHelmChartDependencies(
     return [];
   }
 
-  const componentKey = componentName.replace('-', '_');
+  const componentKey: string = componentKeyFromName(componentName);
 
   const chartVersions: Map<string, string> = defaults[componentKey].charts;
   if (!chartVersions) {

--- a/src/commodore-helm/index.ts
+++ b/src/commodore-helm/index.ts
@@ -101,7 +101,9 @@ export async function extractAllPackageFiles(
 
   if (!fileContents.has('defaults')) {
     logger.error('Component repository has no `class/defaults.ya?ml`');
+    return null;
   }
+
   if (!componentName) {
     logger.error(
       { packageFiles },
@@ -109,17 +111,7 @@ export async function extractAllPackageFiles(
     );
     return null;
   }
-  if (!defaults_file) {
-    logger.error({ packageFiles }, 'Could not identify defaults file');
-    return null;
-  }
-  if (!fileContents.has('defaults') || !fileContents.has(componentName)) {
-    logger.error(
-      { classes: fileContents.keys() },
-      'One or more class files are missing'
-    );
-    return null;
-  }
+
   const defaults: any = yaml.load(fileContents.get('defaults') ?? '');
   const component: any = yaml.load(fileContents.get(componentName) ?? '');
 

--- a/src/commodore-helm/index.ts
+++ b/src/commodore-helm/index.ts
@@ -1,0 +1,226 @@
+import yaml from 'js-yaml';
+
+import path from 'path';
+
+import type {
+  ExtractConfig,
+  PackageFile,
+  PackageDependency,
+} from 'renovate/dist/manager/types';
+
+import { SkipReason } from 'renovate/dist/types';
+
+import { logger } from 'renovate/dist/logger';
+
+import { readLocalFile } from 'renovate/dist/util/fs';
+
+export const defaultConfig = {
+  // match all class files of the component
+  fileMatch: ['class/[^.]+.ya?ml$'],
+};
+
+// We need `extractPackageFile` since it gets called by `confirmIfDepUpdated`
+// via `doAutoReplace` because we don't provide a custom `updateDependency`
+// function ourselves.
+// Note that this is only called to verify the upgraded version, the actual
+// dependency extraction is done with `extractAllPackageFiles`.
+export function extractPackageFile(
+  content: string,
+  fileName: string,
+  config: any
+): PackageFile | null {
+  logger.info(
+    { depName: config.depName, baseDeps: config.baseDeps },
+    'extractPackageFile upgrade'
+  );
+  if (path.parse(fileName).name != 'defaults') {
+    return null;
+  }
+  const defaults: any = yaml.load(content);
+  if (!defaults || !defaults.parameters) {
+    return null;
+  }
+  const dep = config.baseDeps.find((d: PackageDependency) => {
+    return d.depName === config.depName;
+  });
+  const componentKey: string = dep.groupName.replace('-', '_');
+  const charts: Map<string, string> = defaults.parameters[componentKey].charts;
+  if (!charts) {
+    return null;
+  }
+
+  let deps: PackageDependency[] = Object.entries(charts).map(
+    ([chartName, chartVersion]) => {
+      let res: PackageDependency = {
+        depName: chartName,
+        currentValue: chartVersion,
+      };
+      return res;
+    }
+  );
+
+  return { deps };
+}
+
+export async function extractAllPackageFiles(
+  _config: ExtractConfig,
+  packageFiles: string[]
+): Promise<PackageFile[] | null> {
+  let fileContents: Map<string, string> = new Map();
+  let componentName: string | null = null;
+  let defaults_file: string | null = null;
+
+  for (const file of packageFiles) {
+    const content = await readLocalFile(file, 'utf8');
+    const key = path.parse(file).name;
+    fileContents.set(key, content);
+    if (key != 'defaults') {
+      componentName = key;
+    } else {
+      defaults_file = file;
+    }
+  }
+
+  if (!fileContents.has('defaults')) {
+    logger.error('Component repository has no `class/defaults.ya?ml`');
+  }
+  if (!componentName) {
+    logger.error(
+      { packageFiles },
+      'Unable to identify component name from package files'
+    );
+    return null;
+  }
+  if (!defaults_file) {
+    logger.error({ packageFiles }, 'Could not identify defaults file');
+    return null;
+  }
+  if (!fileContents.has('defaults') || !fileContents.has(componentName)) {
+    logger.error(
+      { classes: fileContents.keys() },
+      'One or more class files are missing'
+    );
+    return null;
+  }
+  const defaults: any = yaml.load(fileContents.get('defaults') ?? '');
+  const component: any = yaml.load(fileContents.get(componentName) ?? '');
+
+  if (
+    defaults === undefined ||
+    defaults === null ||
+    defaults.parameters === undefined ||
+    defaults.parameters === null ||
+    component === undefined ||
+    component === null ||
+    component.parameters === undefined ||
+    component.parameters === null
+  ) {
+    return null;
+  }
+
+  const deps: PackageDependency[] = extractHelmChartDependencies(
+    componentName,
+    defaults.parameters,
+    component.parameters
+  );
+
+  if (deps.length == 0) {
+    return null;
+  }
+
+  return [{ packageFile: defaults_file, datasource: 'helm', deps }];
+}
+
+interface KapitanDependency {
+  type: string;
+  source: string;
+  output_path: string;
+}
+interface KapitanHelmDependency extends KapitanDependency {
+  chart_name: string;
+  version: string;
+}
+
+function extractHelmChartDependencies(
+  componentName: string,
+  defaults: Record<string, any>,
+  componentParams: Record<string, any>
+): PackageDependency[] {
+  if (
+    componentName === '' ||
+    defaults === undefined ||
+    defaults === null ||
+    typeof defaults !== 'object' ||
+    componentParams === undefined ||
+    componentParams === null ||
+    typeof componentParams !== 'object'
+  ) {
+    return [];
+  }
+
+  const componentKey = componentName.replace('-', '_');
+
+  const chartVersions: Map<string, string> = defaults[componentKey].charts;
+  if (!chartVersions) {
+    logger.info('No Helm chart versions found');
+    return [];
+  }
+  logger.debug({ chartVersions }, 'chart versions');
+
+  const kapitanHelmDeps: KapitanHelmDependency[] =
+    componentParams.kapitan.dependencies.filter(
+      (dep: KapitanDependency): dep is KapitanHelmDependency =>
+        dep.type === 'helm'
+    );
+  logger.debug({ kapitanHelmDeps }, 'kapitan helm dependencies');
+
+  const deps: PackageDependency[] = Object.entries(chartVersions).map(
+    ([chartName, chartVersion]) => {
+      let res: PackageDependency = {
+        depName: chartName,
+        groupName: componentName,
+        currentValue: chartVersion,
+      };
+
+      const versionReference =
+        '${' + componentKey + ':charts:' + chartName + '}';
+      const dep = kapitanHelmDeps.find((d) => {
+        return d.version === versionReference;
+      });
+      logger.debug({ chartName, dep }, 'kapitan dependency for chart');
+
+      if (!dep || !dep.chart_name) {
+        if (!dep) {
+          logger.warn(
+            { chartName, versionReference },
+            'no Kapitan dependency found for chart'
+          );
+        }
+        res.skipReason = SkipReason.InvalidDependencySpecification;
+        return res;
+      }
+      if (!dep.source) {
+        logger.warn(
+          { chartName },
+          'Kapitan dependency has no source, skipping...'
+        );
+        res.skipReason = SkipReason.NoSource;
+        return res;
+      }
+
+      if (dep.chart_name !== res.depName) {
+        logger.info(
+          { dependencyName: dep.chart_name, versionName: res.depName },
+          'mismatched chart name between version and dependency, using depedency name for version lookup.'
+        );
+        res.depName = dep.chart_name;
+      }
+      res.registryUrls = [dep.source];
+
+      return res;
+    }
+  );
+
+  logger.debug({ deps }, 'extracted');
+  return deps;
+}

--- a/src/commodore-helm/index.ts
+++ b/src/commodore-helm/index.ts
@@ -178,6 +178,14 @@ function extractHelmChartDependencies(
 
   const componentKey: string = componentKeyFromName(componentName);
 
+  if (!defaults[componentKey]) {
+    logger.warn(
+      { defaults, componentKey },
+      "Couldn't find component key in defaults class"
+    );
+    return [];
+  }
+
   const chartVersions: Map<string, string> = defaults[componentKey].charts;
   if (!chartVersions) {
     logger.info('No Helm chart versions found');

--- a/src/commodore-helm/index.ts
+++ b/src/commodore-helm/index.ts
@@ -193,6 +193,11 @@ function extractHelmChartDependencies(
   }
   logger.debug({ chartVersions }, 'chart versions');
 
+  if (!componentParams.kapitan || !componentParams.kapitan.dependencies) {
+    logger.info('No Kapitan dependencies found');
+    return [];
+  }
+
   const kapitanHelmDeps: KapitanHelmDependency[] =
     componentParams.kapitan.dependencies.filter(
       (dep: KapitanDependency): dep is KapitanHelmDependency =>

--- a/src/commodore-helm/index.ts
+++ b/src/commodore-helm/index.ts
@@ -33,11 +33,16 @@ export function extractPackageFile(
   fileName: string,
   config: any
 ): PackageFile | null {
-  logger.info(
-    { depName: config.depName, baseDeps: config.baseDeps },
+  logger.debug(
+    { fileName, depName: config.depName, baseDeps: config.baseDeps },
     'extractPackageFile upgrade'
   );
+  if (!config.depName || !config.baseDeps) {
+    logger.warn({ fileName }, 'extractPackageFile() called for file without dependency info in config');
+    return null;
+  }
   if (path.parse(fileName).name != 'defaults') {
+    logger.warn({ fileName }, 'extractPackageFile() called for a package file other than `defaults.yml`, returning null');
     return null;
   }
   const defaults: any = yaml.load(content);

--- a/src/commodore-helm/index.ts
+++ b/src/commodore-helm/index.ts
@@ -88,6 +88,14 @@ export async function extractAllPackageFiles(
   let componentName: string | null = null;
   let defaults_file: string | null = null;
 
+  if (packageFiles.length != 2) {
+    logger.error(
+      { packageFiles },
+      'Expected exactly two package files, aborting.'
+    );
+    return null;
+  }
+
   for (const file of packageFiles) {
     const content = await readLocalFile(file, 'utf8');
     const key = path.parse(file).name;

--- a/src/commodore-helm/index.ts
+++ b/src/commodore-helm/index.ts
@@ -55,8 +55,11 @@ export function extractPackageFile(
 
   let deps: PackageDependency[] = Object.entries(charts).map(
     ([chartName, chartVersion]) => {
+      let d = config.baseDeps.find((d: PackageDependency) => {
+        return d.propSource == chartName;
+      });
       let res: PackageDependency = {
-        depName: chartName,
+        depName: d.depName,
         currentValue: chartVersion,
       };
       return res;
@@ -182,6 +185,13 @@ function extractHelmChartDependencies(
     ([chartName, chartVersion]) => {
       let res: PackageDependency = {
         depName: chartName,
+        // store name of chart version in `class/defaults.yml` in propSource.
+        // This field is only used by the Maven manager, so we should be able
+        // to safely use it to propagate the chart's version field.
+        // This is technically only necessary for charts whose version field
+        // in the component doesn't match the chart's name, but we just set
+        // and use the field unconditionally to keep the code simpler.
+        propSource: chartName,
         groupName: componentName,
         currentValue: chartVersion,
       };

--- a/src/commodore-helm/index.ts
+++ b/src/commodore-helm/index.ts
@@ -38,11 +38,17 @@ export function extractPackageFile(
     'extractPackageFile upgrade'
   );
   if (!config.depName || !config.baseDeps) {
-    logger.warn({ fileName }, 'extractPackageFile() called for file without dependency info in config');
+    logger.warn(
+      { fileName },
+      'extractPackageFile() called for file without dependency info in config'
+    );
     return null;
   }
   if (path.parse(fileName).name != 'defaults') {
-    logger.warn({ fileName }, 'extractPackageFile() called for a package file other than `defaults.yml`, returning null');
+    logger.warn(
+      { fileName },
+      'extractPackageFile() called for a package file other than `defaults.yml`, returning null'
+    );
     return null;
   }
   const defaults: any = yaml.load(content);

--- a/src/commodore-helm/index.ts
+++ b/src/commodore-helm/index.ts
@@ -107,7 +107,7 @@ export async function extractAllPackageFiles(
     }
   }
 
-  if (!fileContents.has('defaults')) {
+  if (!fileContents.has('defaults') || !defaults_file) {
     logger.error('Component repository has no `class/defaults.ya?ml`');
     return null;
   }

--- a/src/commodore-helm/index.ts
+++ b/src/commodore-helm/index.ts
@@ -58,8 +58,11 @@ export function extractPackageFile(
   const dep = config.baseDeps.find((d: PackageDependency) => {
     return d.depName === config.depName;
   });
+  if (!dep || !dep.groupName) {
+    return null;
+  }
   const componentKey: string = componentKeyFromName(dep.groupName);
-  const charts: Map<string, string> = defaults.parameters[componentKey].charts;
+  const charts: Map<string, string> = defaults.parameters[componentKey]?.charts;
   if (!charts) {
     return null;
   }
@@ -70,9 +73,13 @@ export function extractPackageFile(
         return d.propSource == chartName;
       });
       let res: PackageDependency = {
-        depName: d.depName,
         currentValue: chartVersion,
       };
+      if (d && d.depName) {
+        res.depName = d.depName;
+      } else {
+        res.skipReason = SkipReason.InvalidDependencySpecification;
+      }
       return res;
     }
   );

--- a/src/commodore-helm/readme.md
+++ b/src/commodore-helm/readme.md
@@ -1,0 +1,13 @@
+# Commodore Helm manager
+
+This manager extracts Helm chart dependencies of a Commodore component.
+
+By default, the manager processes all the files in `class/` in a single operation.
+This behavior shouldn't be changed, since the Helm dependency discovery needs to be able to parse data from both `class/defaults.yml` and `class/<component-name>.yml`.
+
+The manager is guaranteed to find Helm chart references which adhere to the [best practices for Helm chart dependencies](https://syn.tools/syn/explanations/commodore-components/helm-charts.html).
+
+In general, the manager will be able to renovate Helm chart references which don't use the exact name of the Helm chart as the field name for the chart version in `parameters.<component-name>.charts`.
+
+The manager doesn't support dependencies which don't have the chart versions specified in `parameters.<component-name>.charts`.
+Additionally, the manager doesn't support Helm chart dependencies which are fetched using Kapitan's generic HTTPS dependency type.

--- a/src/commodore/index.spec.ts
+++ b/src/commodore/index.spec.ts
@@ -6,15 +6,12 @@ import Git from 'simple-git';
 
 import { getGlobalConfig } from 'renovate/dist/config/global';
 
-import { getFixturePath, loadFixture } from '../test/util';
+import { getFixturePath, getLoggerErrors, loadFixture } from '../test/util';
 import { defaultConfig, extractPackageFile } from './index';
 
 import nock from 'nock';
 
-import type { BunyanRecord } from 'renovate/dist/logger/types';
-import { ERROR } from 'bunyan';
-
-import { clearProblems, getProblems } from 'renovate/dist/logger';
+import { clearProblems } from 'renovate/dist/logger';
 
 const params1 = loadFixture('1/params.yml');
 const kube2 = loadFixture('2/kubernetes.yml');
@@ -22,11 +19,6 @@ const invalid3 = loadFixture('3/params.yml');
 const pin4 = loadFixture('4/pins.yml');
 const tenant1 = loadFixture('5/tenant/c-foo.yml');
 const tenant2 = loadFixture('5/tenant/c-foo-2.yml');
-
-function getLoggerErrors(): BunyanRecord[] {
-  const loggerErrors = getProblems().filter((p) => p.level >= ERROR);
-  return loggerErrors;
-}
 
 jest.mock('renovate/dist/config/global');
 function mockGetGlobalConfig(

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,10 +5,12 @@ import { logger } from 'renovate/dist/logger';
 
 import * as commodore from './commodore';
 import * as commodoreDocker from './commodore-docker';
+import * as commodoreHelm from './commodore-helm';
 import { globalRepos } from './commodore/util';
 
 api.set('commodore', commodore);
 api.set('commodore-docker', commodoreDocker);
+api.set('commodore-helm', commodoreHelm);
 
 // Patch renovate option validation to accept `commodore.extraConfig`
 // parameter.

--- a/src/test/util.ts
+++ b/src/test/util.ts
@@ -1,6 +1,11 @@
 import { readFileSync } from 'fs';
 import upath from 'upath';
 
+import type { BunyanRecord } from 'renovate/dist/logger/types';
+import { ERROR } from 'bunyan';
+
+import { getProblems } from 'renovate/dist/logger';
+
 function getCallerFileName(): string {
   let result = '';
 
@@ -43,4 +48,9 @@ export function getFixturePath(fixtureFile: string, fixtureRoot = '.'): string {
 export function loadFixture(fixtureFile: string, fixtureRoot = '.'): string {
   const fixtureAbsFile = getFixturePath(fixtureFile, fixtureRoot);
   return readFileSync(fixtureAbsFile, { encoding: 'utf8' });
+}
+
+export function getLoggerErrors(): BunyanRecord[] {
+  const loggerErrors = getProblems().filter((p) => p.level >= ERROR);
+  return loggerErrors;
 }


### PR DESCRIPTION
This PR introduces a new manager `commodore-helm`, which extracts Helm charts from the component defaults. This manager is implemented with `extractAllPackageFiles`, because we need to correlate information found in `class/defaults.yml` with information found in `class/<component-name>yml`.

The manager currently only supports Helm charts for which the version is specified in field `charts` in `parameters.<component_name>` and which are fetched by Kapitan using the Helm dependency type with their version indicated by `${<component_name>:charts:<chart_name>}`.

The manager currently can't extract the Helm repository URL for Helm charts which are specified in different ways (e.g. using Kapitan HTTPS dependencies).

<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.

Contributors guide: ./CONTRIBUTING.md
-->

## Checklist

<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] PR contains a single logical change (to build a better changelog).
- [x] Update the documentation.
- [x] Update tests.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
