### PR TITLE
Add support for new best-practice Helm chart dependency format

### DIFF
--- a/src/commodore-helm/__fixtures__/7/class/component-name.yml
+++ b/src/commodore-helm/__fixtures__/7/class/component-name.yml
@@ -1,0 +1,22 @@
+parameters:
+  kapitan:
+    dependencies:
+      - type: https
+        source: https://example.com/test.yaml
+        output_path: test.yaml
+      - type: helm
+        source: ${component_name:charts:chart-1:source}
+        chart_name: chart-1
+        version: ${component_name:charts:chart-1:version}
+        output_path: charts/chart-1
+      - type: helm
+        source: https://charts2.example.com/
+        chart_name: chart-2
+        version: ${component_name:charts:chart-2}
+        output_path: charts/chart-2
+      # This entry should be ignored
+      - type: helm
+        source: https://charts3.example.com/
+        chart_name: chart-3
+        version: v0.0.1
+        output_path: charts/chart-3

--- a/src/commodore-helm/__fixtures__/7/class/defaults.yml
+++ b/src/commodore-helm/__fixtures__/7/class/defaults.yml
@@ -1,0 +1,12 @@
+parameters:
+  component_name:
+    charts:
+      chart-1:
+        version: 1.2.3
+        source: https://charts.example.com/
+      chart-2: 4.5.6
+    other_parameter: test
+  other_key:
+    testing: true
+    charts:
+      chart-3: 7.8.9

--- a/src/commodore-helm/__snapshots__/index.spec.ts.snap
+++ b/src/commodore-helm/__snapshots__/index.spec.ts.snap
@@ -23,13 +23,12 @@ Array [
 ]
 `;
 
-exports[`manager/commodore-helm/index extractAllPackageFiles() extracts standard Helm dependencies 1`] = `
+exports[`manager/commodore-helm/index extractAllPackageFiles() extracts new and old standard Helm dependencies in the same file 1`] = `
 Array [
   Object {
     "currentValue": "1.2.3",
     "depName": "chart-1",
     "groupName": "component-name",
-    "propSource": "chart-1",
     "registryUrls": Array [
       "https://charts.example.com/",
     ],
@@ -38,7 +37,27 @@ Array [
     "currentValue": "4.5.6",
     "depName": "chart-2",
     "groupName": "component-name",
-    "propSource": "chart-2",
+    "registryUrls": Array [
+      "https://charts2.example.com/",
+    ],
+  },
+]
+`;
+
+exports[`manager/commodore-helm/index extractAllPackageFiles() extracts standard Helm dependencies 1`] = `
+Array [
+  Object {
+    "currentValue": "1.2.3",
+    "depName": "chart-1",
+    "groupName": "component-name",
+    "registryUrls": Array [
+      "https://charts.example.com/",
+    ],
+  },
+  Object {
+    "currentValue": "4.5.6",
+    "depName": "chart-2",
+    "groupName": "component-name",
     "registryUrls": Array [
       "https://charts2.example.com/",
     ],
@@ -52,7 +71,6 @@ Array [
     "currentValue": "1.2.3",
     "depName": "chart-1",
     "groupName": "long-component-name",
-    "propSource": "chart-1",
     "registryUrls": Array [
       "https://charts.example.com/",
     ],
@@ -61,7 +79,6 @@ Array [
     "currentValue": "4.5.6",
     "depName": "chart-2",
     "groupName": "long-component-name",
-    "propSource": "chart-2",
     "registryUrls": Array [
       "https://charts2.example.com/",
     ],
@@ -75,7 +92,6 @@ Array [
     "currentValue": "1.2.3",
     "depName": "chart-1",
     "groupName": "component-name",
-    "propSource": "chart-1",
     "skipReason": "invalid-dependency-specification",
   },
 ]
@@ -87,7 +103,6 @@ Array [
     "currentValue": "4.5.6",
     "depName": "chart-1",
     "groupName": "component-name-2",
-    "propSource": "chart-1",
     "skipReason": "invalid-dependency-specification",
   },
 ]
@@ -98,6 +113,22 @@ Array [
   Object {
     "currentValue": "1.2.3",
     "depName": "chart-1",
+  },
+  Object {
+    "currentValue": "4.5.6",
+    "depName": "chart-2",
+  },
+]
+`;
+
+exports[`manager/commodore-helm/index extractPackageFile() extracts Helm chart versions from new and old standard 1`] = `
+Array [
+  Object {
+    "currentValue": "1.2.3",
+    "depName": "chart-1",
+    "registryUrls": Array [
+      "https://charts.example.com/",
+    ],
   },
   Object {
     "currentValue": "4.5.6",

--- a/src/commodore-helm/__snapshots__/index.spec.ts.snap
+++ b/src/commodore-helm/__snapshots__/index.spec.ts.snap
@@ -69,6 +69,30 @@ Array [
 ]
 `;
 
+exports[`manager/commodore-helm/index extractAllPackageFiles() gracefully ignores components with old standard \`charts\` parameter but no Kapitan config 1`] = `
+Array [
+  Object {
+    "currentValue": "1.2.3",
+    "depName": "chart-1",
+    "groupName": "component-name",
+    "propSource": "chart-1",
+    "skipReason": "invalid-dependency-specification",
+  },
+]
+`;
+
+exports[`manager/commodore-helm/index extractAllPackageFiles() gracefully ignores components with old standard \`charts\` parameter but no Kapitan helm dependencies 1`] = `
+Array [
+  Object {
+    "currentValue": "4.5.6",
+    "depName": "chart-1",
+    "groupName": "component-name-2",
+    "propSource": "chart-1",
+    "skipReason": "invalid-dependency-specification",
+  },
+]
+`;
+
 exports[`manager/commodore-helm/index extractPackageFile() extracts Helm chart versions for mismatched keys when called with sufficient config 1`] = `
 Array [
   Object {
@@ -99,7 +123,7 @@ exports[`manager/commodore-helm/index extractPackageFile() handles wrong depende
 Array [
   Object {
     "currentValue": "1.2.3",
-    "skipReason": "invalid-dependency-specification",
+    "depName": "chart-1",
   },
   Object {
     "currentValue": "4.5.6",

--- a/src/commodore-helm/__snapshots__/index.spec.ts.snap
+++ b/src/commodore-helm/__snapshots__/index.spec.ts.snap
@@ -1,28 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`manager/commodore-helm/index extractAllPackageFiles() extracts Helm dependencies with mismatched names 1`] = `
-Array [
-  Object {
-    "currentValue": "1.2.3",
-    "depName": "chart-1",
-    "groupName": "component-name",
-    "propSource": "chart_1",
-    "registryUrls": Array [
-      "https://charts.example.com/",
-    ],
-  },
-  Object {
-    "currentValue": "4.5.6",
-    "depName": "chart-2",
-    "groupName": "component-name",
-    "propSource": "chart2",
-    "registryUrls": Array [
-      "https://charts2.example.com/",
-    ],
-  },
-]
-`;
-
 exports[`manager/commodore-helm/index extractAllPackageFiles() extracts new and old standard Helm dependencies in the same file 1`] = `
 Array [
   Object {
@@ -44,7 +21,7 @@ Array [
 ]
 `;
 
-exports[`manager/commodore-helm/index extractAllPackageFiles() extracts standard Helm dependencies 1`] = `
+exports[`manager/commodore-helm/index extractAllPackageFiles() extracts old standard Helm dependencies 1`] = `
 Array [
   Object {
     "currentValue": "1.2.3",
@@ -65,7 +42,7 @@ Array [
 ]
 `;
 
-exports[`manager/commodore-helm/index extractAllPackageFiles() extracts standard Helm dependencies for components with long names 1`] = `
+exports[`manager/commodore-helm/index extractAllPackageFiles() extracts old standard Helm dependencies for components with long names 1`] = `
 Array [
   Object {
     "currentValue": "1.2.3",
@@ -79,6 +56,29 @@ Array [
     "currentValue": "4.5.6",
     "depName": "chart-2",
     "groupName": "long-component-name",
+    "registryUrls": Array [
+      "https://charts2.example.com/",
+    ],
+  },
+]
+`;
+
+exports[`manager/commodore-helm/index extractAllPackageFiles() extracts old-style Helm dependencies with mismatched names 1`] = `
+Array [
+  Object {
+    "currentValue": "1.2.3",
+    "depName": "chart-1",
+    "groupName": "component-name",
+    "propSource": "chart_1",
+    "registryUrls": Array [
+      "https://charts.example.com/",
+    ],
+  },
+  Object {
+    "currentValue": "4.5.6",
+    "depName": "chart-2",
+    "groupName": "component-name",
+    "propSource": "chart2",
     "registryUrls": Array [
       "https://charts2.example.com/",
     ],

--- a/src/commodore-helm/index.spec.ts
+++ b/src/commodore-helm/index.spec.ts
@@ -32,12 +32,10 @@ const config1 = {
   baseDeps: [
     {
       depName: 'chart-1',
-      propSource: 'chart-1',
       groupName: 'component-name',
     },
     {
       depName: 'chart-2',
-      propSource: 'chart-2',
       groupName: 'component-name',
     },
   ],
@@ -51,11 +49,9 @@ const config1partial2 = {
   baseDeps: [
     {
       depName: 'chart-1',
-      propSource: 'chart-1',
     },
     {
       depName: 'chart-2',
-      propSource: 'chart-2',
     },
   ],
 };
@@ -67,9 +63,8 @@ const config1wrong1 = {
       groupName: 'component-name',
     },
     {
-      depName: 'chart-2',
+      depName: 'chart-3',
       groupName: 'component-name',
-      propSource: 'chart-5',
     },
   ],
 };
@@ -237,7 +232,7 @@ describe('manager/commodore-helm/index', () => {
       expect(errors.length).toBe(0);
       expect(res).toBeNull();
     });
-    it('gracefully ignores components with `charts` parameter but no Kapitan config', async () => {
+    it('gracefully ignores components with old standard `charts` parameter but no Kapitan config', async () => {
       mockGetGlobalConfig('5');
       const res = await extractAllPackageFiles({}, [
         'class/defaults.yml',
@@ -248,9 +243,20 @@ describe('manager/commodore-helm/index', () => {
         console.log(errors);
       }
       expect(errors.length).toBe(0);
-      expect(res).toBeNull();
+      expect(res).not.toBeNull();
+      if (res) {
+        expect(res.length).toBe(1);
+        const res0 = res[0];
+        expect(res0).not.toBeNull();
+        if (res0) {
+          expect(res0.packageFile).toBe('class/defaults.yml');
+          const deps = res0.deps;
+          expect(deps).toMatchSnapshot();
+          expect(deps.length).toBe(1);
+        }
+      }
     });
-    it('gracefully ignores components with `charts` parameter but no Kapitan helm dependencies', async () => {
+    it('gracefully ignores components with old standard `charts` parameter but no Kapitan helm dependencies', async () => {
       mockGetGlobalConfig('5');
       const res = await extractAllPackageFiles({}, [
         'class/defaults.yml',
@@ -261,7 +267,18 @@ describe('manager/commodore-helm/index', () => {
         console.log(errors);
       }
       expect(errors.length).toBe(0);
-      expect(res).toBeNull();
+      expect(res).not.toBeNull();
+      if (res) {
+        expect(res.length).toBe(1);
+        const res0 = res[0];
+        expect(res0).not.toBeNull();
+        if (res0) {
+          expect(res0.packageFile).toBe('class/defaults.yml');
+          const deps = res0.deps;
+          expect(deps).toMatchSnapshot();
+          expect(deps.length).toBe(1);
+        }
+      }
     });
     it("records an error for repositories which don't have exactly 2 package files", async () => {
       const res = await extractAllPackageFiles({}, ['class/defaults.yml']);

--- a/src/commodore-helm/index.spec.ts
+++ b/src/commodore-helm/index.spec.ts
@@ -27,6 +27,7 @@ beforeEach(() => {
 const defaults1 = loadFixture('1/class/defaults.yml');
 const defaults3 = loadFixture('3/class/defaults.yml');
 const defaults4 = loadFixture('4/class/defaults.yml');
+const defaults7 = loadFixture('7/class/defaults.yml');
 const config1 = {
   depName: 'chart-1',
   baseDeps: [
@@ -128,6 +129,14 @@ describe('manager/commodore-helm/index', () => {
     });
     it('extracts Helm chart versions when called with sufficient config', () => {
       const res = extractPackageFile(defaults1, 'class/defaults.yml', config1);
+      expect(res).not.toBeNull();
+      if (res) {
+        expect(res.deps).toMatchSnapshot();
+        expect(res.deps.length).toBe(2);
+      }
+    });
+    it('extracts Helm chart versions from new and old standard', () => {
+      const res = extractPackageFile(defaults7, 'class/defaults.yml', config1);
       expect(res).not.toBeNull();
       if (res) {
         expect(res.deps).toMatchSnapshot();
@@ -300,6 +309,29 @@ describe('manager/commodore-helm/index', () => {
       expect(err0.msg).toBe(
         'Component repository has no `class/defaults.ya?ml`'
       );
+    });
+    it('extracts new and old standard Helm dependencies in the same file', async () => {
+      mockGetGlobalConfig('7');
+      const res = await extractAllPackageFiles({}, [
+        'class/defaults.yml',
+        'class/component-name.yml',
+      ]);
+      const errors = getLoggerErrors();
+      if (errors.length > 0) {
+        console.log(errors);
+      }
+      expect(errors.length).toBe(0);
+      expect(res).not.toBeNull();
+      if (res) {
+        expect(res.length).toBe(1);
+        if (res.length == 1) {
+          const res0 = res[0];
+          expect(res0.packageFile).toBe('class/defaults.yml');
+          const deps = res0.deps;
+          expect(deps).toMatchSnapshot();
+          expect(deps.length).toBe(2);
+        }
+      }
     });
   });
 });

--- a/src/commodore-helm/index.spec.ts
+++ b/src/commodore-helm/index.spec.ts
@@ -159,7 +159,7 @@ describe('manager/commodore-helm/index', () => {
   // This test also covers `extractHelmChartDependencies()`, since that's the
   // function which does the heavy lifting for `extractAllPackageFiles()`.
   describe('extractAllPackageFiles()', () => {
-    it('extracts standard Helm dependencies', async () => {
+    it('extracts old standard Helm dependencies', async () => {
       mockGetGlobalConfig('1');
       const res = await extractAllPackageFiles({}, [
         'class/defaults.yml',
@@ -182,7 +182,7 @@ describe('manager/commodore-helm/index', () => {
         }
       }
     });
-    it('extracts standard Helm dependencies for components with long names', async () => {
+    it('extracts old standard Helm dependencies for components with long names', async () => {
       mockGetGlobalConfig('2');
       const res = await extractAllPackageFiles({}, [
         'class/defaults.yml',
@@ -205,7 +205,7 @@ describe('manager/commodore-helm/index', () => {
         }
       }
     });
-    it('extracts Helm dependencies with mismatched names', async () => {
+    it('extracts old-style Helm dependencies with mismatched names', async () => {
       mockGetGlobalConfig('3');
       const res = await extractAllPackageFiles({}, [
         'class/defaults.yml',

--- a/src/commodore-helm/index.ts
+++ b/src/commodore-helm/index.ts
@@ -14,6 +14,17 @@ import { logger } from 'renovate/dist/logger';
 
 import { readLocalFile } from 'renovate/dist/util/fs';
 
+interface KapitanDependency {
+  type: string;
+  source: string;
+  output_path: string;
+}
+
+interface KapitanHelmDependency extends KapitanDependency {
+  chart_name: string;
+  version: string;
+}
+
 export const defaultConfig = {
   // match all class files of the component
   fileMatch: ['class/[^.]+.ya?ml$'],
@@ -154,16 +165,6 @@ export async function extractAllPackageFiles(
   }
 
   return [{ packageFile: defaults_file, datasource: 'helm', deps }];
-}
-
-interface KapitanDependency {
-  type: string;
-  source: string;
-  output_path: string;
-}
-interface KapitanHelmDependency extends KapitanDependency {
-  chart_name: string;
-  version: string;
 }
 
 function extractHelmChartDependencies(

--- a/src/commodore-helm/readme.md
+++ b/src/commodore-helm/readme.md
@@ -7,7 +7,36 @@ This behavior shouldn't be changed, since the Helm dependency discovery needs to
 
 The manager is guaranteed to find Helm chart references which adhere to the [best practices for Helm chart dependencies](https://syn.tools/syn/explanations/commodore-components/helm-charts.html).
 
-In general, the manager will be able to renovate Helm chart references which don't use the exact name of the Helm chart as the field name for the chart version in `parameters.<component-name>.charts`.
-
 The manager doesn't support dependencies which don't have the chart versions specified in `parameters.<component-name>.charts`.
-Additionally, the manager doesn't support Helm chart dependencies which are fetched using Kapitan's generic HTTPS dependency type.
+Please be aware that the manager doesn't support Helm chart dependencies which are fetched using Kapitan's generic HTTPS dependency type.
+
+Finally, the manager also supports the old recommended format for Helm chart dependencies, where only the chart version is given in component parameter `charts`, and the source is only present in `parameters.kapitan.dependencies`.
+
+The old format roughly has the following structure:
+
+In `class/defaults.yml`:
+
+```yaml
+parameters:
+  the_component:
+    charts:
+      my-chart: v1.2.3
+```
+
+In `class/the-component.yml`:
+
+```yaml
+parameters:
+  kapitan:
+    dependencies:
+      - type: helm
+        source: https://charts.appuio.ch/
+        chart_name: my-chart
+        version: ${the_component:charts:my-chart}
+        output_path: path/to/save/chart
+```
+
+In general, the manager will be able to renovate old standard Helm chart references which don't use the exact name of the Helm chart as the field name for the chart version in `parameters.<component-name>.charts`.
+
+> :warning: Support for the old default format may be dropped without prior notice.
+> The Commodore Helm manager offers support for the old format only to allow gradual transition to the new best practice format.


### PR DESCRIPTION
Follow-up for #17 to implement support for the new best-practice Helm chart dependency specification format defined in https://github.com/projectsyn/documentation/pull/150

## Checklist

<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] PR contains a single logical change (to build a better changelog).
- [x] Update the documentation.
- [x] Update tests.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Link this PR to related issues.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
