### PR TITLE
Change error log messages to warnings in commodore-helm

### DIFF
--- a/src/commodore-helm/index.spec.ts
+++ b/src/commodore-helm/index.spec.ts
@@ -285,9 +285,10 @@ describe('manager/commodore-helm/index', () => {
       const res = await extractAllPackageFiles({}, ['class/defaults.yml']);
       expect(res).toBeNull();
       const errors = getLoggerErrors();
-      expect(errors.length).toBe(1);
-      const err0 = errors[0];
-      expect(err0.msg).toBe('Expected exactly two package files, aborting.');
+      if (errors.length > 0) {
+        console.log(errors);
+      }
+      expect(errors.length).toBe(0);
     });
     it('records an error for non-component repositories which have two package files', async () => {
       const res = await extractAllPackageFiles({}, [
@@ -296,11 +297,10 @@ describe('manager/commodore-helm/index', () => {
       ]);
       expect(res).toBeNull();
       const errors = getLoggerErrors();
-      expect(errors.length).toBe(1);
-      const err0 = errors[0];
-      expect(err0.msg).toBe(
-        'Component repository has no `class/defaults.ya?ml`'
-      );
+      if (errors.length > 0) {
+        console.log(errors);
+      }
+      expect(errors.length).toBe(0);
     });
     it('extracts new and old standard Helm dependencies in the same file', async () => {
       setGlobalConfig('7');

--- a/src/commodore-helm/index.ts
+++ b/src/commodore-helm/index.ts
@@ -129,9 +129,9 @@ export async function extractAllPackageFiles(
   let defaults_file: string | null = null;
 
   if (packageFiles.length != 2) {
-    logger.error(
+    logger.warn(
       { packageFiles },
-      'Expected exactly two package files, aborting.'
+      'Expected exactly two package files, skipping.'
     );
     return null;
   }
@@ -148,14 +148,14 @@ export async function extractAllPackageFiles(
   }
 
   if (!fileContents.has('defaults') || !defaults_file) {
-    logger.error('Component repository has no `class/defaults.ya?ml`');
+    logger.warn('Repository has no `class/defaults.ya?ml`, skipping');
     return null;
   }
 
   if (!componentName) {
-    logger.error(
+    logger.warn(
       { packageFiles },
-      'Unable to identify component name from package files'
+      'Unable to identify component name from package files, skipping'
     );
     return null;
   }


### PR DESCRIPTION
This allows us to enable the manager globally without Renovate exiting with an error if the manager is active on a repo which isn't a component repo.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.

Contributors guide: ./CONTRIBUTING.md
-->

## Checklist

<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] PR contains a single logical change (to build a better changelog).
- [x] Update tests.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog


<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
