### PR TITLE
Add Commodore binary dependencies in container image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,6 +38,20 @@ RUN install-apt build-essential
 COPY requirements.txt .
 RUN pip install  -r requirements.txt
 
+# Install Commodore binary dependencies
+RUN curl -fsSL -o get_helm.sh https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3 \
+ && chmod 700 get_helm.sh \
+ && ./get_helm.sh \
+ && mv /usr/local/bin/helm /usr/local/bin/helm3 \
+ && curl -LO https://git.io/get_helm.sh \
+ && chmod 700 get_helm.sh \
+ && ./get_helm.sh \
+ && mv /usr/local/bin/helm /usr/local/bin/helm2 \
+ && rm ./get_helm.sh \
+ && ln -s /usr/local/bin/helm3 /usr/local/bin/helm \
+ && curl -fsSLo /usr/local/bin/jb https://github.com/jsonnet-bundler/jsonnet-bundler/releases/download/v0.4.0/jb-linux-amd64 \
+ && chmod +x /usr/local/bin/jb
+
 RUN set -ex; \
   chmod +x /usr/src/app/bin/index.js; \
   ln -sf /usr/src/app/bin/index.js /usr/local/bin/renovate;


### PR DESCRIPTION
This is necessary to run `commodore component compile` directly using the Commodore copy in the container image.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.

Contributors guide: ./CONTRIBUTING.md
-->

## Checklist

<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
