### PR TITLE
Add missing build dependency libffi-dev for Python 3.10

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,7 +34,7 @@ COPY --from=tsbuild /usr/src/app/node_modules node_modules
 
 # renovate: datasource=github-releases lookupName=containerbase/python-prebuild
 RUN install-tool python 3.10.4
-RUN install-apt build-essential
+RUN install-apt build-essential libffi-dev
 COPY requirements.txt .
 RUN pip install  -r requirements.txt
 


### PR DESCRIPTION
Since Python 3.10, we need to install libffi-dev to build Python packages which use C FFI.

Follow-up to #51 

<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.

Contributors guide: ./CONTRIBUTING.md
-->

## Checklist

<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Link this PR to related issues.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
