### PR TITLE
Fix two null value errors

### DIFF
--- a/src/commodore-helm/index.ts
+++ b/src/commodore-helm/index.ts
@@ -137,7 +137,7 @@ export async function extractAllPackageFiles(
   }
 
   for (const file of packageFiles) {
-    const content = await readLocalFile(file, 'utf8');
+    const content = (await readLocalFile(file, 'utf8')) ?? '';
     const key = path.parse(file).name;
     fileContents.set(key, content);
     if (key != 'defaults') {

--- a/src/commodore/index.ts
+++ b/src/commodore/index.ts
@@ -215,9 +215,13 @@ export async function extractPackageFile(
     parse(fileName).name
   }-extra.yaml`;
 
-  const extraConfigStr: string = config.extraConfig
-    ? (await readLocalFile(config.extraConfig)).toString()
-    : '{}';
+  let extraConfigStr: string = '{}';
+  if (config.extraConfig) {
+    const file = await readLocalFile(config.extraConfig);
+    if (file !== null) {
+      extraConfigStr = file.toString();
+    }
+  }
   // Merge user-supplied extra config with defaults
   let extraConfig = { ...defaultExtraConfig };
   extraConfig = mergeConfig(extraConfig, globalExtraConfig);


### PR DESCRIPTION
Yarn suddenly decided two variables can be null and really doesn't like that..

Ignore as this wasn't released yet and really doesn't help in the changelog

## Checklist

<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] PR contains a single logical change (to build a better changelog).


<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
