### PR TITLE
Fix default cloud region regex to not extract regions with slashes

### DIFF
--- a/src/commodore/index.ts
+++ b/src/commodore/index.ts
@@ -38,7 +38,7 @@ export const defaultExtraConfig = {
   distributionRegex:
     /^distribution\/(?<distribution>[^\/]+)(?:\/cloud\/(?<cloud>.+)\.ya?ml|(?:\/.+)?\.ya?ml)$/,
   cloudRegionRegex:
-    /^cloud\/(?<cloud>[^\/]+)(?:\/(?<region>[^\/]+)\.ya?ml|.*\.ya?ml)$/,
+    /^cloud\/(?<cloud>[^\/]+)(?:\/(?<region>[^\/]+)\.ya?ml|.+\.ya?ml)$/,
   ignoreValues: ['params'],
   // map facts to files
   factsMap: {} as any,

--- a/src/commodore/index.ts
+++ b/src/commodore/index.ts
@@ -38,7 +38,7 @@ export const defaultExtraConfig = {
   distributionRegex:
     /^distribution\/(?<distribution>[^\/]+)(?:\/cloud\/(?<cloud>.+)\.ya?ml|(?:\/.+)?\.ya?ml)$/,
   cloudRegionRegex:
-    /^cloud\/(?<cloud>[^\/]+)(?:\/(?<region>.+)\.ya?ml|\.ya?ml)$/,
+    /^cloud\/(?<cloud>[^\/]+)(?:\/(?<region>[^\/]+)\.ya?ml|.*\.ya?ml)$/,
   ignoreValues: ['params'],
   // map facts to files
   factsMap: {} as any,

--- a/src/commodore/index.ts
+++ b/src/commodore/index.ts
@@ -38,7 +38,7 @@ export const defaultExtraConfig = {
   distributionRegex:
     /^distribution\/(?<distribution>[^\/]+)(?:\/cloud\/(?<cloud>.+)\.ya?ml|(?:\/.+)?\.ya?ml)$/,
   cloudRegionRegex:
-    /^cloud\/(?<cloud>[^\/]+)(?:\/(?<region>[^\/]+)\.ya?ml|.+\.ya?ml)$/,
+    /^cloud\/(?<cloud>[^\/]+)(?:\/(?<region>[^\/]+)\.ya?ml|[^\/]*\.ya?ml)$/,
   ignoreValues: ['params'],
   // map facts to files
   factsMap: {} as any,

--- a/src/commodore/index.ts
+++ b/src/commodore/index.ts
@@ -38,7 +38,7 @@ export const defaultExtraConfig = {
   distributionRegex:
     /^distribution\/(?<distribution>[^\/]+)(?:\/cloud\/(?<cloud>.+)\.ya?ml|(?:\/.+)?\.ya?ml)$/,
   cloudRegionRegex:
-    /^cloud\/(?<cloud>[^\/]+)(?:\/(?<region>[^\/]+)\.ya?ml|[^\/]*\.ya?ml)$/,
+    /^cloud\/(?<cloud>[^\/]+)(?:\/(?:(?<region>[^\/]+)|.+)\.ya?ml|\.ya?ml)$/,
   ignoreValues: ['params'],
   // map facts to files
   factsMap: {} as any,

--- a/src/commodore/readme.md
+++ b/src/commodore/readme.md
@@ -62,7 +62,7 @@ The manager currently understands the following keys in the extra configuration 
   The manager will also use a named capture group `region` as the cloud provider region, if it exists.
   The regex pattern should be written such that it matches the relative file path of a cloud class in the global defaults repository.
 
-  Default: `/^cloud\/(?<cloud>[^\/]+)(?:\/(?<region>[^\/]+)\.ya?ml|[^\/]*\.ya?ml)$/`
+  Default: `/^cloud\/(?<cloud>[^\/]+)(?:\/(?:(?<region>[^\/]+)|.+)\.ya?ml|\.ya?ml)$/`
 
   The default regex pattern extracts the cloud (and optionally cloud region) name from file names in the following forms (and additionally the same forms with `.yaml` file extensions):
 

--- a/src/commodore/readme.md
+++ b/src/commodore/readme.md
@@ -62,7 +62,7 @@ The manager currently understands the following keys in the extra configuration 
   The manager will also use a named capture group `region` as the cloud provider region, if it exists.
   The regex pattern should be written such that it matches the relative file path of a cloud class in the global defaults repository.
 
-  Default: `/^cloud\/(?<cloud>[^\/]+)(?:\/(?<region>[^\/]+)\.ya?ml|.+\.ya?ml)$/`.
+  Default: `/^cloud\/(?<cloud>[^\/]+)(?:\/(?<region>[^\/]+)\.ya?ml|[^\/]*\.ya?ml)$/`
 
   The default regex pattern extracts the cloud (and optionally cloud region) name from file names in the following forms (and additionally the same forms with `.yaml` file extensions):
 

--- a/src/commodore/readme.md
+++ b/src/commodore/readme.md
@@ -62,12 +62,13 @@ The manager currently understands the following keys in the extra configuration 
   The manager will also use a named capture group `region` as the cloud provider region, if it exists.
   The regex pattern should be written such that it matches the relative file path of a cloud class in the global defaults repository.
 
-  Default: `/^cloud\/(?<cloud>[^\/]+)(?:\/(?<region>.+)\.ya?ml|\.ya?ml)$/`.
+  Default: `/^cloud\/(?<cloud>[^\/]+)(?:\/(?<region>[^\/]+)\.ya?ml|.+\.ya?ml)$/`.
 
   The default regex pattern extracts the cloud (and optionally cloud region) name from file names in the following forms (and additionally the same forms with `.yaml` file extensions):
 
   - `cloud/<cloud>.yml`
   - `cloud/<cloud>/<region>.yml`
+  - `cloud/<cloud>/foo/bar.yml`
 
 - `ignoreValues`: An array of strings to ignore if they appear as distribution, cloud or region values.
   The manager will not use distribution, cloud, or region values which match an entry in this array when calling `commodore inventory show`.

--- a/src/commodore/util.spec.ts
+++ b/src/commodore/util.spec.ts
@@ -32,7 +32,18 @@ describe('src/commodore/util', () => {
       ${'distribution/dist.yml'}             | ${{ distribution: 'dist', cloud: null, region: null }}
       ${'cloud/cloud.yml'}                   | ${{ distribution: null, cloud: 'cloud', region: null }}
       ${'cloud/cloud/region.yml'}            | ${{ distribution: null, cloud: 'cloud', region: 'region' }}
+      ${'cloud/cloud2/region2.yaml'}         | ${{ distribution: null, cloud: 'cloud2', region: 'region2' }}
       ${'cloud/cloud/params.yml'}            | ${{ distribution: null, cloud: 'cloud', region: null }}
+      ${'cloud/cloud2/params.yaml'}          | ${{ distribution: null, cloud: 'cloud2', region: null }}
+      ${'cloud/cloud/params/param.yml'}      | ${{ distribution: null, cloud: 'cloud', region: null }}
+      ${'cloud/cloud/foo/bar.yml'}           | ${{ distribution: null, cloud: 'cloud', region: null }}
+      ${'cloud/cloud2/foo/bar/buzz.yaml'}    | ${{ distribution: null, cloud: 'cloud2', region: null }}
+      ${'cloud/cloud2/foo/.yaml'}            | ${{ distribution: null, cloud: 'cloud2', region: null }}
+      ${'cloud/cloud//.yml'}                 | ${{ distribution: null, cloud: 'cloud', region: null }}
+      ${'cloud/cloud/.yml'}                  | ${{ distribution: null, cloud: null, region: null }}
+      ${'cloud/cloudnt/.yaml'}               | ${{ distribution: null, cloud: null, region: null }}
+      ${'cloud/cloud/notyml.json'}           | ${{ distribution: null, cloud: null, region: null }}
+      ${'cloud/cloud/notyml.sh'}             | ${{ distribution: null, cloud: null, region: null }}
       ${'distribution/dist/cloud/cloud.yml'} | ${{ distribution: 'dist', cloud: 'cloud', region: null }}
     `('returns $fact for $file', ({ file, fact }) => {
       const f = util.parseFileName(
@@ -42,7 +53,6 @@ describe('src/commodore/util', () => {
         defaultExtraConfig.ignoreValues
       );
 
-      expect(hasFact(f)).toBe(true);
       expect(f.distribution).toBe(fact.distribution);
       expect(f.cloud).toBe(fact.cloud);
       expect(f.region).toBe(fact.region);


### PR DESCRIPTION
The updated regex will not extract wrong regions from subdirectory in cloud directory.

I.E `cloud/cloudscale/foo/bar` will not get any region instead of region `foo/bar`.

## Checklist

<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] PR contains a single logical change (to build a better changelog).
- [ ] Update tests.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
