### PR TITLE
Allow up to 5 Renovate PRs per week

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,6 @@
 {
   "extends": ["config:base", "schedule:weekly"],
+  "prHourlyLimit": 5,
   "python": {
     "enabled": true
   },


### PR DESCRIPTION
Since we're running renovate with `schedule:weekly`, increasing the hourly PR limit makes sense, since we only get one batch of PRs per week, and the default of 2 PRs isn't really sufficient to get PRs for all dependencies which were upgraded during a whole week.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.

Contributors guide: ./CONTRIBUTING.md
-->

## Checklist

<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] PR contains a single logical change (to build a better changelog)
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
