### PR TITLE
Add missing `libmagic1` in container image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,7 +38,7 @@ RUN install-tool python 3.11.1
 # because otherwise the python packages which need to build C extensions can't
 # find Python.h
 RUN ln -s /opt/buildpack/tools/python /usr/local/python
-RUN install-apt build-essential libffi-dev
+RUN install-apt build-essential libffi-dev libmagic1
 COPY requirements.txt .
 RUN pip install  -r requirements.txt
 


### PR DESCRIPTION
Required by Commodore v1.15.0/Kapitan 0.31.0, cf. https://github.com/projectsyn/commodore/commit/8896815980d82bb05b3d4132aa60065b8b02b0ca

Follow-up to #118 
<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.

Contributors guide: ./CONTRIBUTING.md
-->

## Checklist

<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Link this PR to related issues.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
