### PR TITLE
Use GitHub releases instead of git refs where possible

### DIFF
--- a/src/commodore/__fixtures__/1/params.yml
+++ b/src/commodore/__fixtures__/1/params.yml
@@ -19,6 +19,9 @@ parameters:
     lieutenant:
       url: https://github.com/projectsyn/component-lieutenant.git
       version: v2.2.0
+    foo-test:
+      url: https://gitlab.com/projectsyn/component-foo-test.git
+      version: v2.2.0
   packages:
     monitoring:
       url: https://github.com/projectsyn/package-monitoring

--- a/src/commodore/__snapshots__/index.spec.ts.snap
+++ b/src/commodore/__snapshots__/index.spec.ts.snap
@@ -4,18 +4,21 @@ exports[`src/commodore/index extractPackageFile() extracts component and package
 [
   {
     "currentValue": "v3.0.0",
+    "datasource": "github-releases",
     "depName": "component-appuio-cloud in 4/pins.yml",
-    "packageName": "https://github.com/appuio/component-appuio-cloud.git",
+    "packageName": "appuio/component-appuio-cloud",
   },
   {
     "currentValue": "v1.2.3",
+    "datasource": "github-releases",
     "depName": "component-argocd in 4/pins.yml",
-    "packageName": "https://github.com/projectsyn/component-argocd.git",
+    "packageName": "projectsyn/component-argocd",
   },
   {
     "currentValue": "v0.9.0",
+    "datasource": "github-releases",
     "depName": "package-monitoring in 4/pins.yml",
-    "packageName": "https://github.com/projectsyn/package-monitoring",
+    "packageName": "projectsyn/package-monitoring",
   },
 ]
 `;
@@ -24,18 +27,21 @@ exports[`src/commodore/index extractPackageFile() extracts component and package
 [
   {
     "currentValue": "v3.0.0",
+    "datasource": "github-releases",
     "depName": "component-appuio-cloud in 5/tenant/c-foo.yml",
-    "packageName": "https://github.com/appuio/component-appuio-cloud.git",
+    "packageName": "appuio/component-appuio-cloud",
   },
   {
     "currentValue": "v1.2.3",
+    "datasource": "github-releases",
     "depName": "component-argocd in 5/tenant/c-foo.yml",
-    "packageName": "https://github.com/projectsyn/component-argocd.git",
+    "packageName": "projectsyn/component-argocd",
   },
   {
     "currentValue": "v0.9.0",
+    "datasource": "github-releases",
     "depName": "package-monitoring in 5/tenant/c-foo.yml",
-    "packageName": "https://github.com/projectsyn/package-monitoring",
+    "packageName": "projectsyn/package-monitoring",
   },
 ]
 `;
@@ -44,38 +50,51 @@ exports[`src/commodore/index extractPackageFile() extracts component and package
 [
   {
     "currentValue": "v1.1.0",
+    "datasource": "github-releases",
     "depName": "component-appuio-cloud in 1/params.yml",
-    "packageName": "https://github.com/appuio/component-appuio-cloud.git",
+    "packageName": "appuio/component-appuio-cloud",
   },
   {
     "currentValue": "v1.0.0",
+    "datasource": "github-releases",
     "depName": "component-appuio-cloud2 in 1/params.yml",
-    "packageName": "https://github.com/appuio/component-appuio-cloud.git",
+    "packageName": "appuio/component-appuio-cloud",
   },
   {
     "currentValue": "v1.0.0",
+    "datasource": "github-releases",
     "depName": "component-argocd in 1/params.yml",
-    "packageName": "https://github.com/projectsyn/component-argocd.git",
+    "packageName": "projectsyn/component-argocd",
   },
   {
     "currentValue": "v2.1.0",
+    "datasource": "github-releases",
     "depName": "component-backup-k8up in 1/params.yml",
-    "packageName": "https://github.com/projectsyn/component-backup-k8up.git",
+    "packageName": "projectsyn/component-backup-k8up",
   },
   {
     "currentValue": "v1.0.0",
+    "datasource": "github-releases",
     "depName": "component-kyverno in 1/params.yml",
-    "packageName": "https://github.com/projectsyn/component-kyverno.git",
+    "packageName": "projectsyn/component-kyverno",
   },
   {
     "currentValue": "v2.2.0",
+    "datasource": "github-releases",
     "depName": "component-lieutenant in 1/params.yml",
-    "packageName": "https://github.com/projectsyn/component-lieutenant.git",
+    "packageName": "projectsyn/component-lieutenant",
+  },
+  {
+    "currentValue": "v2.2.0",
+    "datasource": "git-refs",
+    "depName": "component-foo-test in 1/params.yml",
+    "packageName": "https://gitlab.com/projectsyn/component-foo-test.git",
   },
   {
     "currentValue": "v1.0.0",
+    "datasource": "github-releases",
     "depName": "package-monitoring in 1/params.yml",
-    "packageName": "https://github.com/projectsyn/package-monitoring",
+    "packageName": "projectsyn/package-monitoring",
   },
 ]
 `;
@@ -84,18 +103,21 @@ exports[`src/commodore/index extractPackageFile() generates valid Commodore para
 [
   {
     "currentValue": "v3.0.0",
+    "datasource": "github-releases",
     "depName": "component-appuio-cloud in 5/tenant/c-foo-4.yml",
-    "packageName": "https://github.com/appuio/component-appuio-cloud.git",
+    "packageName": "appuio/component-appuio-cloud",
   },
   {
     "currentValue": "v1.2.3",
+    "datasource": "github-releases",
     "depName": "component-argocd in 5/tenant/c-foo-4.yml",
-    "packageName": "https://github.com/projectsyn/component-argocd-k3d.git",
+    "packageName": "projectsyn/component-argocd-k3d",
   },
   {
     "currentValue": "v0.9.0",
+    "datasource": "github-releases",
     "depName": "package-monitoring in 5/tenant/c-foo-4.yml",
-    "packageName": "https://github.com/projectsyn/package-k3d-monitoring",
+    "packageName": "projectsyn/package-k3d-monitoring",
   },
 ]
 `;
@@ -104,18 +126,21 @@ exports[`src/commodore/index extractPackageFile() proceeds without cluster info 
 [
   {
     "currentValue": "v3.0.0",
+    "datasource": "github-releases",
     "depName": "component-appuio-cloud in 5/tenant/c-foo-3.yml",
-    "packageName": "https://github.com/appuio/component-appuio-cloud.git",
+    "packageName": "appuio/component-appuio-cloud",
   },
   {
     "currentValue": "v1.2.3",
+    "datasource": "github-releases",
     "depName": "component-argocd in 5/tenant/c-foo-3.yml",
-    "packageName": "https://github.com/projectsyn/component-argocd.git",
+    "packageName": "projectsyn/component-argocd",
   },
   {
     "currentValue": "v0.9.0",
+    "datasource": "github-releases",
     "depName": "package-monitoring in 5/tenant/c-foo-3.yml",
-    "packageName": "https://github.com/projectsyn/package-monitoring",
+    "packageName": "projectsyn/package-monitoring",
   },
 ]
 `;
@@ -124,18 +149,21 @@ exports[`src/commodore/index extractPackageFile() uses cluster info returned by 
 [
   {
     "currentValue": "v3.0.0",
+    "datasource": "github-releases",
     "depName": "component-appuio-cloud in 5/tenant/c-foo-2.yml",
-    "packageName": "https://github.com/appuio/component-appuio-cloud.git",
+    "packageName": "appuio/component-appuio-cloud",
   },
   {
     "currentValue": "v1.2.3",
+    "datasource": "github-releases",
     "depName": "component-argocd in 5/tenant/c-foo-2.yml",
-    "packageName": "https://github.com/projectsyn/component-argocd-k3d.git",
+    "packageName": "projectsyn/component-argocd-k3d",
   },
   {
     "currentValue": "v0.9.0",
+    "datasource": "github-releases",
     "depName": "package-monitoring in 5/tenant/c-foo-2.yml",
-    "packageName": "https://github.com/projectsyn/package-k3d-monitoring",
+    "packageName": "projectsyn/package-k3d-monitoring",
   },
 ]
 `;
@@ -144,18 +172,21 @@ exports[`src/commodore/index extractPackageFile() uses facts from factsMap 1`] =
 [
   {
     "currentValue": "v3.0.0",
+    "datasource": "github-releases",
     "depName": "component-appuio-cloud in 5/tenant/test.yml",
-    "packageName": "https://github.com/appuio/component-appuio-cloud.git",
+    "packageName": "appuio/component-appuio-cloud",
   },
   {
     "currentValue": "v1.2.3",
+    "datasource": "github-releases",
     "depName": "component-argocd in 5/tenant/test.yml",
-    "packageName": "https://github.com/projectsyn/component-argocd-k3d.git",
+    "packageName": "projectsyn/component-argocd-k3d",
   },
   {
     "currentValue": "v0.9.0",
+    "datasource": "github-releases",
     "depName": "package-monitoring in 5/tenant/test.yml",
-    "packageName": "https://github.com/projectsyn/package-k3d-monitoring",
+    "packageName": "projectsyn/package-k3d-monitoring",
   },
 ]
 `;

--- a/src/commodore/index.spec.ts
+++ b/src/commodore/index.spec.ts
@@ -125,7 +125,7 @@ describe('src/commodore/index', () => {
       if (res) {
         const deps = res.deps;
         expect(deps).toMatchSnapshot();
-        expect(deps).toHaveLength(7);
+        expect(deps).toHaveLength(8);
       }
     });
     it('returns no component or package version for files without components or packages', () => {

--- a/src/commodore/readme.md
+++ b/src/commodore/readme.md
@@ -12,6 +12,9 @@ The manager will optionally try to fetch cluster info from Lieutenant.
 Data returned from Lieutenant will be provided to `commodore inventory show` to infer more accurate component and package URLs (e.g. if an URL is overridden for a distribution).
 This feature is only available for tenant repositories, and only if configuration parameters `lieutenantURL` and `lieutenantToken` are set.
 
+For Commodore components hosted on GitHub, the manager will use GitHub releases as the data source for detecting new versions.
+For all other git hosts, it will use git refs, detecting versions from among the repository's git tags and git heads.
+
 ## Configuration
 
 The Commodore manager requires some non-standard configurations.
@@ -81,6 +84,10 @@ The manager currently understands the following keys in the extra configuration 
   However, values returned from Lieutenant have precedence over values provided in the `factsMap`.
 
   Default: `{}`.
+
+- `githubBaseUrl`: A string containing the base URL of GitHub, used to distinguish between GitHub repositories and other git hosts.
+
+  Default: `https://github.com/`
 
 The manager uses the results of the `distributionRegex` and `cloudRegionRegex` patterns, the values provided in `factsMap`, and the Lieutenant API response to construct an inventory class providing the facts to Commodore.
 


### PR DESCRIPTION
GitHub releases support the `releaseTimestamp` field, which is necessary for `minimumReleaseAge` to work.

It's not the prettiest implementation, but it works. Happy to hear suggestions for how to improve it.
<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.

Contributors guide: ./CONTRIBUTING.md
-->

## Checklist

<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] PR contains a single logical change (to build a better changelog).
- [x] Update tests.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
