### PR TITLE
Make the Commodore binary available in PATH with containerbase v11

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -68,3 +68,7 @@ jobs:
         with:
           push: false
           tags: 'ghcr.io/${{ env.IMAGE }}:test'
+      - name: Test that Commodore is available in PATH in the built container
+        if: contains(steps.changed-files.outputs.modified_files, 'Dockerfile')
+        run: |
+          docker run --rm ghcr.io/${{ env.IMAGE }}:test commodore

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ WORKDIR /usr/src/app
 
 
 
-FROM base as tsbuild
+FROM base AS tsbuild
 
 # renovate: datasource=npm versioning=npm
 RUN install-tool yarn 1.22.22
@@ -25,9 +25,9 @@ RUN yarn build
 
 
 
-FROM base as final
+FROM base AS final
 
-ENV NODE_ENV production
+ENV NODE_ENV=production
 
 COPY --from=tsbuild /usr/src/app/bin bin
 COPY --from=tsbuild /usr/src/app/node_modules node_modules

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,15 +32,16 @@ ENV NODE_ENV=production
 COPY --from=tsbuild /usr/src/app/bin bin
 COPY --from=tsbuild /usr/src/app/node_modules node_modules
 
-# renovate: datasource=github-releases lookupName=containerbase/python-prebuild
-RUN install-tool python 3.11.9
-# Create a symlink from /opt/buildpack/tools/python to /usr/local/python
-# because otherwise the python packages which need to build C extensions can't
-# find Python.h
-RUN ln -s /opt/buildpack/tools/python /usr/local/python
+# renovate: datasource=github-releases lookupName=containerbase/python-prebuild depname=python
+ARG PYTHON_VERSION=3.11.9
+RUN install-tool python ${PYTHON_VERSION}
 RUN install-apt build-essential libffi-dev libmagic1
 COPY requirements.txt .
 RUN pip install  -r requirements.txt
+# Containerbase v11 doesn't put /opt/containerbase/tools/python/<VERSION>/bin
+# into the path anymore, so we do it ourselves by appending it to
+# /usr/local/etc/env which is sourced by the containerbase entrypoint script.
+RUN echo "export PATH=/opt/containerbase/tools/python/${PYTHON_VERSION}/bin:\${PATH}" >> /usr/local/etc/env
 
 # renovate: datasource=github-releases lookupName=kubernetes-sigs/kustomize depname=kustomize
 ARG KUSTOMIZE_VERSION=4.5.7


### PR DESCRIPTION
Containerbase v11 has removed the tool `bin/` directories from the PATH, which breaks commodore-renovate, since we rely on `commodore` being available in the PATH (cf. https://github.com/containerbase/base/commit/2ca2238b1cb73b9c79270c46e82aff16f802b91f).

This commit adjusts the Dockerfile to prepend the installed python tool directory `bin/` to the PATH.

Follow-up to #299 

## Checklist

<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] PR contains a single logical change (to build a better changelog).
- [x] Update tests.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Link this PR to related issues.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
