### PR TITLE
Patch kapitan in commodore-renovate container image to use reclass-rs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -64,7 +64,9 @@ RUN curl -fsSL -o get_helm.sh https://raw.githubusercontent.com/helm/helm/master
  && curl -fsSLO "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh" \
  && chmod +x install_kustomize.sh \
  && ./install_kustomize.sh ${KUSTOMIZE_VERSION} /usr/local/bin \
- && rm ./install_kustomize.sh
+ && rm ./install_kustomize.sh \
+ && curl -L https://raw.githubusercontent.com/projectsyn/reclass-rs/main/hack/kapitan_0.32_reclass_rs.patch \
+ | patch -p1 -d "$(python -c 'import kapitan; print(kapitan.__path__[0])')"
 
 RUN set -ex; \
   chmod +x /usr/src/app/bin/index.js; \


### PR DESCRIPTION
This fixes issues with `make gen-golden` for components which no longer compile with Python reclass.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.

Contributors guide: ./CONTRIBUTING.md
-->

## Checklist

<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
