### PR TITLE
Update Renovate regex managers for Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,7 +32,7 @@ ENV NODE_ENV=production
 COPY --from=tsbuild /usr/src/app/bin bin
 COPY --from=tsbuild /usr/src/app/node_modules node_modules
 
-# renovate: datasource=github-releases lookupName=containerbase/python-prebuild depname=python
+# renovate: datasource=github-releases packageName=containerbase/python-prebuild depname=python
 ARG PYTHON_VERSION=3.11.9
 RUN install-tool python ${PYTHON_VERSION}
 RUN install-apt build-essential libffi-dev libmagic1
@@ -43,9 +43,9 @@ RUN pip install  -r requirements.txt
 # /usr/local/etc/env which is sourced by the containerbase entrypoint script.
 RUN echo "export PATH=/opt/containerbase/tools/python/${PYTHON_VERSION}/bin:\${PATH}" >> /usr/local/etc/env
 
-# renovate: datasource=github-releases lookupName=kubernetes-sigs/kustomize depname=kustomize
+# renovate: datasource=github-releases packageName=kubernetes-sigs/kustomize depname=kustomize versionTemplate=^kustomize/v(?<version>.*)$
 ARG KUSTOMIZE_VERSION=4.5.7
-# renovate: datasource=github-releases lookupName=projectsyn/jsonnet-bundler depname=jsonnet-bundler
+# renovate: datasource=github-releases packageName=projectsyn/jsonnet-bundler depname=jsonnet-bundler
 ARG JSONNET_BUNDLER_VERSION=v0.6.2
 
 # Install Commodore binary dependencies

--- a/renovate.json
+++ b/renovate.json
@@ -9,7 +9,7 @@
       "description": "Update install-* Buildpack commands in Dockerfiles",
       "fileMatch": ["(^|/|\\.)Dockerfile$", "(^|/)Dockerfile\\.[^/]*$"],
       "matchStrings": [
-        "# renovate: datasource=(?<datasource>[a-z-]+?)(?: lookupName=(?<lookupName>.+?))?(?: versioning=(?<versioning>[a-z-]+?))?\\sRUN install-[a-z]+? (?<depName>[a-z-]+?) (?<currentValue>.+?)\\s"
+        "# renovate: datasource=(?<datasource>[a-z-]+?)(?: packageName=(?<packageName>.+?))?(?: versioning=(?<versioning>[a-z-]+?))?\\sRUN install-[a-z]+? (?<depName>[a-z-]+?) (?<currentValue>.+?)\\s"
       ],
       "versioningTemplate": "{{#if versioning}}{{versioning}}{{else}}semver{{/if}}"
     },
@@ -17,9 +17,10 @@
       "description": "Update version ENV variables in Dockerfiles",
       "fileMatch": ["(^|/|\\.)Dockerfile$", "(^|/)Dockerfile\\.[^/]*$"],
       "matchStrings": [
-        "# renovate: datasource=(?<datasource>[a-z-]+?)(?: lookupName=(?<lookupName>.+?))?(?: versioning=(?<versioning>[a-z-]+?))?(?: depname=(?<depName>[a-z-]+?))?\\sARG [A-Z_]+_VERSION=(?<currentValue>.+?)\\s"
+        "# renovate: datasource=(?<datasource>[a-z-]+?)(?: packageName=(?<packageName>.+?))?(?: versioning=(?<versioning>[a-z-]+?))?(?: depname=(?<depName>[a-z-]+?))?(?: versionTemplate=(?<versionTemplate>[a-z-]+?))?\\sARG [A-Z_]+_VERSION=(?<currentValue>.+?)\\s"
       ],
-      "versioningTemplate": "{{#if versioning}}{{versioning}}{{else}}semver{{/if}}"
+      "versioningTemplate": "{{#if versioning}}{{versioning}}{{else}}semver{{/if}}",
+      "extractVersionTemplate": "{{#if versionTemplate}}{{versionTemplate}}{{else}}^(?<version>.*)${{/if}}"
     }
   ],
   "packageRules": [


### PR DESCRIPTION
We update the regex managers to use `packageName` instead of `lookupName` as required for Renovate v32+.

Additionally, we add optional comment field `versionTemplate` so we can handle custom Git tag formats such as `kustomize/vX.Y.Z`.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.

Contributors guide: ./CONTRIBUTING.md
-->

## Checklist

<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog


<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
