### PR TITLE
Fix install of kustomize in container image

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -71,4 +71,16 @@ jobs:
       - name: Test that Commodore is available in PATH in the built container
         if: contains(steps.changed-files.outputs.modified_files, 'Dockerfile')
         run: |
-          docker run --rm ghcr.io/${{ env.IMAGE }}:test commodore
+          docker run --rm ghcr.io/${{ env.IMAGE }}:test commodore --version
+      - name: Test that Helm is available in PATH in the built container
+        if: contains(steps.changed-files.outputs.modified_files, 'Dockerfile')
+        run: |
+          docker run --rm ghcr.io/${{ env.IMAGE }}:test helm version
+      - name: Test that Kustomize is available in PATH in the built container
+        if: contains(steps.changed-files.outputs.modified_files, 'Dockerfile')
+        run: |
+          docker run --rm ghcr.io/${{ env.IMAGE }}:test kustomize version
+      - name: Test that jsonnet-bundler is available in PATH in the built container
+        if: contains(steps.changed-files.outputs.modified_files, 'Dockerfile')
+        run: |
+          docker run --rm ghcr.io/${{ env.IMAGE }}:test jb --version

--- a/Dockerfile
+++ b/Dockerfile
@@ -63,7 +63,7 @@ RUN curl -fsSL -o get_helm.sh https://raw.githubusercontent.com/helm/helm/master
  && chmod +x /usr/local/bin/jb \
  && curl -fsSLO "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh" \
  && chmod +x install_kustomize.sh \
- && ./install_kustomize.sh ${KUSTOMIZE_VERSION} /usr/local/bin \
+ && ./install_kustomize.sh ${KUSTOMIZE_VERSION} /opt/containerbase/bin \
  && rm ./install_kustomize.sh \
  && curl -L https://raw.githubusercontent.com/projectsyn/reclass-rs/main/hack/kapitan_0.32_reclass_rs.patch \
  | patch -p1 -d "$(python -c 'import kapitan; print(kapitan.__path__[0])')"


### PR DESCRIPTION
The `install_kustomize.sh` script has some logic which resolves symlinks in the install directory path. However, this messes up somehow when resolving the symlink `/usr/local/bin/` which points to `/opt/containerbase/bin`. To avoid this issue, we directly provide `/opt/containerbase/bin` as the install directory.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.

Contributors guide: ./CONTRIBUTING.md
-->

## Checklist

<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] PR contains a single logical change (to build a better changelog).
- [x] Update tests.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
