### PR TITLE
Create real user for UID 1000 so Git SSH clones work

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,6 +27,9 @@ FROM base AS final
 
 ENV NODE_ENV=production
 
+# Setup real user for UID 1000 so ssh Git clones work
+RUN useradd --no-create-home --no-user-group --gid 0 --uid 1000 renovate
+
 COPY --from=tsbuild /usr/src/app/bin bin
 COPY --from=tsbuild /usr/src/app/node_modules node_modules
 


### PR DESCRIPTION
containerbase has removed the `/etc/passwd` entry for UID 1000 at some point. We run `useradd` to create an entry for UID 1000 so we can clone Git repos over SSH.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.

Contributors guide: ./CONTRIBUTING.md
-->

## Checklist

<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
