### PR TITLE
Switch to using UID 12021 of user `ubuntu`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,10 +27,6 @@ FROM base AS final
 
 ENV NODE_ENV=production
 
-# Setup real user for UID 1000 so ssh Git clones work
-RUN useradd --create-home --no-user-group --gid 0 --uid 1000 renovate
-ENV HOME=/home/renovate
-
 COPY --from=tsbuild /usr/src/app/bin bin
 COPY --from=tsbuild /usr/src/app/node_modules node_modules
 
@@ -76,4 +72,4 @@ RUN set -ex; \
   ln -sf /usr/src/app/bin/index.js /usr/local/bin/renovate;
 CMD ["renovate"]
 
-USER 1000
+USER 12021


### PR DESCRIPTION
The containerbase image has a bunch of extra logic in the entrypoint script which makes it tricky to setup a custom user with correct environment variables.

Instead we just switch to using the new UID of user ubuntu (`12021`) for the final container image.

Replaces #371 #376 #377

## Checklist

<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Link this PR to related issues.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
