### PR TITLE
Fix `fileMatch` for commodore-helm manager

### DIFF
--- a/src/commodore-helm/index.spec.ts
+++ b/src/commodore-helm/index.spec.ts
@@ -1,5 +1,9 @@
 import { loadFixture, getFixturePath, getLoggerErrors } from '../test/util';
-import { extractPackageFile, extractAllPackageFiles } from './index';
+import {
+  defaultConfig,
+  extractPackageFile,
+  extractAllPackageFiles,
+} from './index';
 import { beforeEach, expect, describe, it } from '@jest/globals';
 
 import { GlobalConfig } from 'renovate/dist/config/global';
@@ -324,6 +328,15 @@ describe('manager/commodore-helm/index', () => {
           expect(deps.length).toBe(2);
         }
       }
+    });
+    it("doesn't match golden test files as files to renovate", async () => {
+      expect(defaultConfig.fileMatch.length).toBe(1);
+      const re = new RegExp(defaultConfig.fileMatch[0]);
+      expect(re.test('class/defaults.yml')).toBe(true);
+      expect(re.test('class/component-name.yml')).toBe(true);
+      expect(re.test('class/name.yaml')).toBe(true);
+      expect(re.test('tests/golden/storageclass/sc.yaml')).toBe(false);
+      expect(re.test('tests/golden/class/class.yaml')).toBe(false);
     });
   });
 });

--- a/src/commodore-helm/index.ts
+++ b/src/commodore-helm/index.ts
@@ -28,7 +28,7 @@ interface KapitanHelmDependency extends KapitanDependency {
 
 export const defaultConfig = {
   // match all class files of the component
-  fileMatch: ['class/[^.]+.ya?ml$'],
+  fileMatch: ['^class/[^.]+.ya?ml$'],
 };
 
 export const supportedDatasources = [HelmDatasource.id];


### PR DESCRIPTION
We need to anchor the beginning of the `fileMatch` commodore-helm regex `class/[^.].ya?ml$` so that we don't accidentally match any files in golden tests whose name or path contains the fragment `class/`, such as component-rook-ceph's `rbd-extra-storageclass` test case.


Added a test case which tests the `fileMatch` regex pattern against some representative cases.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.

Contributors guide: ./CONTRIBUTING.md
-->

## Checklist

<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
