### PR TITLE
Update Dockerfile for recent Commodore versions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -71,7 +71,7 @@ jobs:
       - name: Test that Commodore is available in PATH in the built container
         if: contains(steps.changed-files.outputs.modified_files, 'Dockerfile')
         run: |
-          docker run --rm ghcr.io/${{ env.IMAGE }}:test commodore --version
+          docker run --rm ghcr.io/${{ env.IMAGE }}:test commodore version
       - name: Test that Helm is available in PATH in the built container
         if: contains(steps.changed-files.outputs.modified_files, 'Dockerfile')
         run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -33,9 +33,6 @@ COPY --from=tsbuild /usr/src/app/node_modules node_modules
 # renovate: datasource=github-releases packageName=containerbase/python-prebuild depname=python
 ARG PYTHON_VERSION=3.12.11
 RUN install-tool python ${PYTHON_VERSION}
-# renovate: datasource=github-releases packageName=containerbase/golang-prebuild depname=golang
-ARG GO_VERSION=1.23.5
-RUN install-tool golang ${GO_VERSION}
 RUN install-apt build-essential libffi-dev libmagic1
 COPY requirements.txt .
 RUN pip install  -r requirements.txt

--- a/Dockerfile
+++ b/Dockerfile
@@ -45,24 +45,18 @@ RUN echo "export PATH=/opt/containerbase/tools/python/${PYTHON_VERSION}/bin:\${P
 ARG KUSTOMIZE_VERSION=5.6.0
 # renovate: datasource=github-releases packageName=projectsyn/jsonnet-bundler depname=jsonnet-bundler
 ARG JSONNET_BUNDLER_VERSION=v0.6.3
+# renovate: datasource=github-releases packageName=helm/helm depname=helm
+ARG HELM_VERSION=v3.18.4
 
 # Install Commodore binary dependencies
-RUN curl -fsSL -o get_helm.sh https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3 \
- && chmod 700 get_helm.sh \
- && ./get_helm.sh \
- && mv /usr/local/bin/helm /usr/local/bin/helm3 \
- && curl -LO https://git.io/get_helm.sh \
- && chmod 700 get_helm.sh \
- && ./get_helm.sh \
- && mv /usr/local/bin/helm /usr/local/bin/helm2 \
- && rm ./get_helm.sh \
- && ln -s /usr/local/bin/helm3 /usr/local/bin/helm \
- && curl -fsSLo /usr/local/bin/jb https://github.com/projectsyn/jsonnet-bundler/releases/download/${JSONNET_BUNDLER_VERSION}/jb_linux_amd64 \
- && chmod +x /usr/local/bin/jb \
- && curl -fsSLO "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh" \
- && chmod +x install_kustomize.sh \
- && ./install_kustomize.sh ${KUSTOMIZE_VERSION} /opt/containerbase/bin \
- && rm ./install_kustomize.sh
+RUN HOME="${USER_HOME}" commodore tool install helm --version ${HELM_VERSION} \
+ && HOME="${USER_HOME}" commodore tool install kustomize --version ${KUSTOMIZE_VERSION} \
+ && HOME="${USER_HOME}" commodore tool install jb --version ${JSONNET_BUNDLER_VERSION} \
+ && ln -s \
+    "${USER_HOME}/.cache/commodore/tools/helm" \
+    "${USER_HOME}/.cache/commodore/tools/jb" \
+    "${USER_HOME}/.cache/commodore/tools/kustomize" \
+    "/usr/local/bin"
 
 RUN set -ex; \
   chmod +x /usr/src/app/bin/index.js; \


### PR DESCRIPTION
* Run `commodore version` when validating built container image
* Remove golang install from Dockerfile since gojsonnet 0.21.0 provides prebuilt wheels
* Use `commodore tool install` to install Commodore's binary dependencies

## Checklist

<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] PR contains a single logical change (to build a better changelog).
- [x] Update tests.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
