### PR TITLE
Add support for renovating OCI Helm charts in Commodore components

### DIFF
--- a/src/commodore-helm/__fixtures__/8/class/component-name.yml
+++ b/src/commodore-helm/__fixtures__/8/class/component-name.yml
@@ -1,0 +1,22 @@
+parameters:
+  kapitan:
+    dependencies:
+      - type: https
+        source: https://example.com/test.yaml
+        output_path: test.yaml
+      - type: helm
+        source: ${component_name:charts:chart-1:source}
+        chart_name: chart-1
+        version: ${component_name:charts:chart-1:version}
+        output_path: charts/chart-1
+      - type: helm
+        source: oci://charts2.example.com/chart-2
+        chart_name: chart-2
+        version: ${component_name:charts:chart-2}
+        output_path: charts/chart-2
+      # This entry should be ignored
+      - type: helm
+        source: https://charts3.example.com/
+        chart_name: chart-3
+        version: v0.0.1
+        output_path: charts/chart-3

--- a/src/commodore-helm/__fixtures__/8/class/defaults.yml
+++ b/src/commodore-helm/__fixtures__/8/class/defaults.yml
@@ -1,0 +1,8 @@
+parameters:
+  component_name:
+    charts:
+      chart-1:
+        version: 1.2.3
+        source: oci://charts.example.com/chart-1
+      chart-2: 4.5.6
+    other_parameter: test

--- a/src/commodore-helm/__snapshots__/index.spec.ts.snap
+++ b/src/commodore-helm/__snapshots__/index.spec.ts.snap
@@ -1,5 +1,30 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
+exports[`manager/commodore-helm/index > extractAllPackageFiles() > extracts OCI charts from new and old Helm dependencies 1`] = `
+[
+  {
+    "currentValue": "1.2.3",
+    "datasource": "docker",
+    "depName": "chart-1",
+    "groupName": "component-name",
+    "packageName": "charts.example.com/chart-1",
+    "registryUrls": [
+      "oci://charts.example.com",
+    ],
+  },
+  {
+    "currentValue": "4.5.6",
+    "datasource": "docker",
+    "depName": "chart-2",
+    "groupName": "component-name",
+    "packageName": "charts2.example.com/chart-2",
+    "registryUrls": [
+      "oci://charts2.example.com",
+    ],
+  },
+]
+`;
+
 exports[`manager/commodore-helm/index > extractAllPackageFiles() > extracts new and old standard Helm dependencies in the same file 1`] = `
 [
   {
@@ -135,6 +160,19 @@ exports[`manager/commodore-helm/index > extractPackageFile() > extracts Helm cha
 `;
 
 exports[`manager/commodore-helm/index > extractPackageFile() > extracts Helm chart versions when called with sufficient config 1`] = `
+[
+  {
+    "currentValue": "1.2.3",
+    "depName": "chart-1",
+  },
+  {
+    "currentValue": "4.5.6",
+    "depName": "chart-2",
+  },
+]
+`;
+
+exports[`manager/commodore-helm/index > extractPackageFile() > extracts OCI Helm chart versions when called with sufficient config 1`] = `
 [
   {
     "currentValue": "1.2.3",

--- a/src/commodore-helm/readme.md
+++ b/src/commodore-helm/readme.md
@@ -10,6 +10,9 @@ The manager is guaranteed to find Helm chart references which adhere to the [bes
 The manager doesn't support dependencies which don't have the chart versions specified in `parameters.<component-name>.charts`.
 Please be aware that the manager doesn't support Helm chart dependencies which are fetched using Kapitan's generic HTTPS dependency type.
 
+Since 0.21.0, the manager also supports renovating OCI Helm chart dependencies.
+For OCI Helm chart dependencies, the manager assumes that `source` (in either format) is the OCI URL of the chart.
+
 Finally, the manager also supports the old recommended format for Helm chart dependencies, where only the chart version is given in component parameter `charts`, and the source is only present in `parameters.kapitan.dependencies`.
 
 The old format roughly has the following structure:


### PR DESCRIPTION
We need to convert the parsed PackageDependency to a Docker datasource dependencies for OCI Helm charts. We use Renovate's `isOCIRegistry()` to determine if a chart source is pointing to an OCI registry and convert the dependency to a Docker datasource dependency with a snippet that we've adapted from Renovate's [Helmfile manager].

[Helmfile manager]: https://github.com/renovatebot/renovate/blob/main/lib/modules/manager/helmfile/extract.ts#L89-L129

## Checklist

<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] PR contains a single logical change (to build a better changelog).
- [x] Update the documentation.
- [x] Update tests.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
